### PR TITLE
Testing and Minor fixes

### DIFF
--- a/Imperium.cat
+++ b/Imperium.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cdc1-e60c-6456-c57a" name="Imperium" revision="38" battleScribeVersion="2.03" authorName="BSData" authorContact="@dndtonight @BSData" authorUrl="http://battlescribedata.appspot.com/#/repo/battlefleetgothic" library="false" gameSystemId="de5d6c5f-ae7b-4dd1-841e-5f1193fb5176" gameSystemRevision="46" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cdc1-e60c-6456-c57a" name="Imperium" revision="39" battleScribeVersion="2.03" authorName="BSData" authorContact="@dndtonight @BSData" authorUrl="http://battlescribedata.appspot.com/#/repo/battlefleetgothic" library="false" gameSystemId="de5d6c5f-ae7b-4dd1-841e-5f1193fb5176" gameSystemRevision="46" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <publications>
     <publication id="44fa-5ffb-b627-7106" name="New Publication"/>
   </publications>
@@ -8,162 +8,162 @@
       <categoryLinks>
         <categoryLink id="9374-68a8-0bb9-1c6f" name="Fleet Commander" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="false">
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="2ae0-9c08-6ab6-e728" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="2ae0-9c08-6ab6-e728" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="f7a7-f5ad-6536-7fc2" name="Escort" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
         <categoryLink id="19b2-4045-60b0-dbe4" name="Special" hidden="false" targetId="5370656369616c23232344415441232323" primary="false"/>
         <categoryLink id="fe11-d831-bf9e-44e6" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0230-705d-7089-7d68" type="max"/>
-            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f44-154d-5a95-f2cb" type="min"/>
+            <constraint field="selections" scope="parent" value="12" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0230-705d-7089-7d68" type="max"/>
+            <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f44-154d-5a95-f2cb" type="min"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="5b77-51cb-718f-cda1" name="Orbital Defences" hidden="false" targetId="90ac-0bee-0c90-be27" primary="false"/>
+        <categoryLink id="5b77-51cb-718f-cda1" name="Orbital Defence" hidden="false" targetId="90ac-0bee-0c90-be27" primary="false"/>
         <categoryLink id="3a48-f788-7b9d-fff9" name="Ordnance" hidden="false" targetId="e70d-1bf2-7ea2-276a" primary="false"/>
-        <categoryLink id="0075-4f17-91e1-8cf4" name="Battleships" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false">
+        <categoryLink id="0075-4f17-91e1-8cf4" name="Battleship" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false">
           <modifiers>
-            <modifier type="increment" field="2f38-32d5-da85-0dcb" value="1.0">
+            <modifier type="increment" field="2f38-32d5-da85-0dcb" value="1">
               <repeats>
-                <repeat field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1042-e458-4e02-a537" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="force" value="3" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1042-e458-4e02-a537" repeats="1" roundUp="false"/>
               </repeats>
               <conditions>
-                <condition field="selections" scope="force" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1042-e458-4e02-a537" type="greaterThan"/>
+                <condition field="selections" scope="force" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1042-e458-4e02-a537" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f38-32d5-da85-0dcb" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f38-32d5-da85-0dcb" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="ba1f-b624-bae8-5374" name="Grand Cruisers" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false"/>
+        <categoryLink id="ba1f-b624-bae8-5374" name="Grand Cruiser" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false"/>
         <categoryLink id="37c5-5f82-70eb-b367" name="Battlecruiser" hidden="false" targetId="b041-ef69-0039-d535" primary="false">
           <modifiers>
-            <modifier type="increment" field="b05e-6024-741e-1596" value="1.0">
+            <modifier type="increment" field="b05e-6024-741e-1596" value="1">
               <repeats>
-                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e0c6-bde4-7055-1e6e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e0c6-bde4-7055-1e6e" repeats="1" roundUp="false"/>
               </repeats>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e0c6-bde4-7055-1e6e" type="greaterThan"/>
+                <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e0c6-bde4-7055-1e6e" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b05e-6024-741e-1596" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b05e-6024-741e-1596" type="max"/>
           </constraints>
         </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="8ed8-4a6a-2f2b-833d" name="Gothic Sector Fleet List, Segmentum Obscurus" publicationId="11f0-17d1-e4d2-1018" page="115" hidden="false">
       <categoryLinks>
-        <categoryLink id="53fb-c3f8-5f56-41cc" name="Fleet Commanders" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="false">
+        <categoryLink id="53fb-c3f8-5f56-41cc" name="Fleet Commander" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="false">
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="1cfc-c817-0deb-39a0" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="1cfc-c817-0deb-39a0" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="20af-e7ac-d00e-0125" name="Battleships" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false">
+        <categoryLink id="20af-e7ac-d00e-0125" name="Battleship" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false">
           <modifiers>
-            <modifier type="increment" field="e760-4f8e-f2c0-eab0" value="1.0">
+            <modifier type="increment" field="e760-4f8e-f2c0-eab0" value="1">
               <repeats>
-                <repeat field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1042-e458-4e02-a537" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="force" value="3" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1042-e458-4e02-a537" repeats="1" roundUp="false"/>
               </repeats>
               <conditions>
-                <condition field="selections" scope="force" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1042-e458-4e02-a537" type="greaterThan"/>
+                <condition field="selections" scope="force" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1042-e458-4e02-a537" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e760-4f8e-f2c0-eab0" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e760-4f8e-f2c0-eab0" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="b2c0-de95-8554-29bd" name="Escorts" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
+        <categoryLink id="b2c0-de95-8554-29bd" name="Escort" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
         <categoryLink id="de43-c13d-503d-fbe3" name="Special" hidden="false" targetId="5370656369616c23232344415441232323" primary="false"/>
-        <categoryLink id="9387-56cf-ff9b-fe15" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="false">
+        <categoryLink id="9387-56cf-ff9b-fe15" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47e5-c7c5-aaeb-c158" type="max"/>
-            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd9d-900f-ee6f-a81c" type="min"/>
+            <constraint field="selections" scope="parent" value="12" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47e5-c7c5-aaeb-c158" type="max"/>
+            <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd9d-900f-ee6f-a81c" type="min"/>
           </constraints>
         </categoryLink>
         <categoryLink id="e204-e945-e9ce-7a1d" name="Grand Cruiser" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false"/>
         <categoryLink id="2f17-2dbe-d576-6514" name="Battlecruiser" hidden="false" targetId="b041-ef69-0039-d535" primary="false">
           <modifiers>
-            <modifier type="increment" field="a959-2f5b-92dd-2a32" value="1.0">
+            <modifier type="increment" field="a959-2f5b-92dd-2a32" value="1">
               <repeats>
-                <repeat field="selections" scope="force" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e0c6-bde4-7055-1e6e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="force" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e0c6-bde4-7055-1e6e" repeats="1" roundUp="false"/>
               </repeats>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e0c6-bde4-7055-1e6e" type="greaterThan"/>
+                <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e0c6-bde4-7055-1e6e" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a959-2f5b-92dd-2a32" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a959-2f5b-92dd-2a32" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="6dcc-c62b-4a52-9d88" name="Orbital Defences" hidden="false" targetId="90ac-0bee-0c90-be27" primary="false"/>
+        <categoryLink id="6dcc-c62b-4a52-9d88" name="Orbital Defence" hidden="false" targetId="90ac-0bee-0c90-be27" primary="false"/>
         <categoryLink id="6002-4f34-7564-7ca8" name="Ordnance" hidden="false" targetId="e70d-1bf2-7ea2-276a" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="c52d-5b11-b7cd-f654" name="Bastion Fleets List, Segmentum Obscurus" publicationId="1bc8-5968-21c3-0f27" page="28" hidden="false">
       <categoryLinks>
-        <categoryLink id="675e-cab6-6248-d13e" name="Fleet Commanders" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="false">
+        <categoryLink id="675e-cab6-6248-d13e" name="Fleet Commander" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="false">
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="55dc-427b-eef1-71c4" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="55dc-427b-eef1-71c4" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="5b32-6b5e-40a4-1365" name="Escorts" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
+        <categoryLink id="5b32-6b5e-40a4-1365" name="Escort" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
         <categoryLink id="a913-a189-4d62-b8b5" name="Special" hidden="false" targetId="5370656369616c23232344415441232323" primary="false"/>
-        <categoryLink id="ba33-87d6-fcac-50a4" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="false">
+        <categoryLink id="ba33-87d6-fcac-50a4" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8791-cbd8-929a-6e94" type="max"/>
-            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8b5-20c2-af6f-3e5b" type="min"/>
+            <constraint field="selections" scope="parent" value="12" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8791-cbd8-929a-6e94" type="max"/>
+            <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8b5-20c2-af6f-3e5b" type="min"/>
           </constraints>
         </categoryLink>
         <categoryLink id="6b82-4f7b-62b0-9c9c" name="Ordnance" hidden="false" targetId="e70d-1bf2-7ea2-276a" primary="false"/>
-        <categoryLink id="eba0-139c-1262-bdc5" name="Orbital Defences" hidden="false" targetId="90ac-0bee-0c90-be27" primary="false"/>
+        <categoryLink id="eba0-139c-1262-bdc5" name="Orbital Defence" hidden="false" targetId="90ac-0bee-0c90-be27" primary="false"/>
         <categoryLink id="2328-5807-9104-c69d" name="Battleship" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false">
           <modifiers>
-            <modifier type="increment" field="63f0-c3d3-ae52-6557" value="1.0">
+            <modifier type="increment" field="63f0-c3d3-ae52-6557" value="1">
               <repeats>
-                <repeat field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1042-e458-4e02-a537" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="force" value="3" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1042-e458-4e02-a537" repeats="1" roundUp="false"/>
               </repeats>
               <conditions>
-                <condition field="selections" scope="force" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1042-e458-4e02-a537" type="greaterThan"/>
+                <condition field="selections" scope="force" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1042-e458-4e02-a537" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63f0-c3d3-ae52-6557" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63f0-c3d3-ae52-6557" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="5c2d-148d-4866-01d8" name="Grand Cruiser" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false">
           <modifiers>
-            <modifier type="increment" field="de81-75d2-c24b-f840" value="1.0">
+            <modifier type="increment" field="de81-75d2-c24b-f840" value="1">
               <repeats>
-                <repeat field="selections" scope="force" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1042-e458-4e02-a537" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="force" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1042-e458-4e02-a537" repeats="1" roundUp="false"/>
               </repeats>
               <conditions>
-                <condition field="selections" scope="force" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1042-e458-4e02-a537" type="atLeast"/>
+                <condition field="selections" scope="force" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1042-e458-4e02-a537" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de81-75d2-c24b-f840" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de81-75d2-c24b-f840" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="0dc7-4121-57c5-217f" name="Battlecruiser" hidden="false" targetId="b041-ef69-0039-d535" primary="false">
           <modifiers>
-            <modifier type="increment" field="42bf-d903-c65f-9670" value="1.0">
+            <modifier type="increment" field="42bf-d903-c65f-9670" value="1">
               <repeats>
-                <repeat field="selections" scope="force" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e0c6-bde4-7055-1e6e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="force" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e0c6-bde4-7055-1e6e" repeats="1" roundUp="false"/>
               </repeats>
               <conditions>
-                <condition field="selections" scope="force" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e0c6-bde4-7055-1e6e" type="atLeast"/>
+                <condition field="selections" scope="force" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e0c6-bde4-7055-1e6e" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42bf-d903-c65f-9670" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42bf-d903-c65f-9670" type="max"/>
           </constraints>
         </categoryLink>
       </categoryLinks>
@@ -171,175 +171,175 @@
     <forceEntry id="7346-ab43-9438-149f" name="Space Marine Fleet List, Codex Astartes (unsupported)" publicationId="1bc8-5968-21c3-0f27" page="30" hidden="false">
       <comment>Should be in Space Marines Faction</comment>
       <categoryLinks>
-        <categoryLink id="e51c-9696-ff49-6e59" name="Fleet Commanders" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="false">
+        <categoryLink id="e51c-9696-ff49-6e59" name="Fleet Commander" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="false">
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="9bbe-cc79-8e5c-a440" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="9bbe-cc79-8e5c-a440" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="8c7e-af38-f513-bab6" name="Battleships" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false">
+        <categoryLink id="8c7e-af38-f513-bab6" name="Battleship" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false">
           <modifiers>
             <modifier type="increment" field="0cda-9157-3759-24d0" value="1">
               <conditions>
-                <condition field="points" scope="force" value="1000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="atLeast"/>
+                <condition field="points" scope="force" value="1000" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="atLeast"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="0cda-9157-3759-24d0" value="1">
               <conditions>
-                <condition field="points" scope="force" value="3000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="atLeast"/>
+                <condition field="points" scope="force" value="3000" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="atLeast"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="0cda-9157-3759-24d0" value="1">
               <conditions>
-                <condition field="points" scope="force" value="2000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="atLeast"/>
+                <condition field="points" scope="force" value="2000" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cda-9157-3759-24d0" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cda-9157-3759-24d0" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="3781-8c38-d629-036a" name="Escorts" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
+        <categoryLink id="3781-8c38-d629-036a" name="Escort" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
         <categoryLink id="8a4f-f1ed-a679-bd9a" name="Special" hidden="false" targetId="5370656369616c23232344415441232323" primary="false"/>
-        <categoryLink id="5ba0-a2a8-0be3-ff1d" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="false">
+        <categoryLink id="5ba0-a2a8-0be3-ff1d" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d589-97bf-1f63-911c" type="max"/>
+            <constraint field="selections" scope="parent" value="10" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d589-97bf-1f63-911c" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="1ffe-dbcf-a2f6-2c34" name="Grand Cruisers" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false"/>
-        <categoryLink id="2212-401d-361a-e35f" name="Heavy Cruisers" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
-        <categoryLink id="4480-8a3f-af57-4711" name="Orbital Defences" hidden="false" targetId="90ac-0bee-0c90-be27" primary="false"/>
+        <categoryLink id="1ffe-dbcf-a2f6-2c34" name="Grand Cruiser" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false"/>
+        <categoryLink id="2212-401d-361a-e35f" name="Heavy Cruiser" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
+        <categoryLink id="4480-8a3f-af57-4711" name="Orbital Defence" hidden="false" targetId="90ac-0bee-0c90-be27" primary="false"/>
         <categoryLink id="8259-f70e-4a38-459a" name="Ordnance" hidden="false" targetId="e70d-1bf2-7ea2-276a" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="5b8b-7613-df6a-8977" name="Black Templars (unsupported)" hidden="false">
       <categoryLinks>
-        <categoryLink id="26b9-c694-be6f-7cc9" name="Fleet Commanders" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="false">
+        <categoryLink id="26b9-c694-be6f-7cc9" name="Fleet Commander" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="false">
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="21f9-4b31-d47e-ec85" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="21f9-4b31-d47e-ec85" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="ef8f-4033-d999-71f7" name="Battleships" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false">
+        <categoryLink id="ef8f-4033-d999-71f7" name="Battleship" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false">
           <modifiers>
             <modifier type="increment" field="ecc4-fd0c-a6ae-25fe" value="1">
               <conditions>
-                <condition field="points" scope="force" value="1000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="atLeast"/>
+                <condition field="points" scope="force" value="1000" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="atLeast"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="ecc4-fd0c-a6ae-25fe" value="1">
               <conditions>
-                <condition field="points" scope="force" value="3000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="atLeast"/>
+                <condition field="points" scope="force" value="3000" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="atLeast"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="ecc4-fd0c-a6ae-25fe" value="1">
               <conditions>
-                <condition field="points" scope="force" value="2000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="atLeast"/>
+                <condition field="points" scope="force" value="2000" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ecc4-fd0c-a6ae-25fe" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ecc4-fd0c-a6ae-25fe" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="5588-94e1-a045-0dbf" name="Escorts" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
+        <categoryLink id="5588-94e1-a045-0dbf" name="Escort" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
         <categoryLink id="a342-0946-8e54-51af" name="Special" hidden="false" targetId="5370656369616c23232344415441232323" primary="false"/>
-        <categoryLink id="fcbc-2b6f-4c13-e906" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="false">
+        <categoryLink id="fcbc-2b6f-4c13-e906" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c52-afd0-3a94-354a" type="max"/>
+            <constraint field="selections" scope="parent" value="12" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c52-afd0-3a94-354a" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="0138-f94d-082b-adce" name="Grand Cruisers" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false"/>
-        <categoryLink id="f415-6dcc-92e7-ccf0" name="Heavy Cruisers" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
-        <categoryLink id="e4e6-c596-93b2-8c8b" name="Orbital Defences" hidden="false" targetId="90ac-0bee-0c90-be27" primary="false"/>
+        <categoryLink id="0138-f94d-082b-adce" name="Grand Cruiser" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false"/>
+        <categoryLink id="f415-6dcc-92e7-ccf0" name="Heavy Cruiser" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
+        <categoryLink id="e4e6-c596-93b2-8c8b" name="Orbital Defence" hidden="false" targetId="90ac-0bee-0c90-be27" primary="false"/>
         <categoryLink id="4d9d-5aa1-3ac0-32f7" name="Ordnance" hidden="false" targetId="e70d-1bf2-7ea2-276a" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="6577-54b5-e6c6-11c5" name="Space Marines Crusade (unsupported)" hidden="false">
       <comment>Should be in Space Marines Faction</comment>
       <categoryLinks>
-        <categoryLink id="5148-0aaa-65b7-fc2b" name="Fleet Commanders" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="false">
+        <categoryLink id="5148-0aaa-65b7-fc2b" name="Fleet Commander" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="false">
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="0c5d-daf0-69e9-57d2" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="0c5d-daf0-69e9-57d2" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="33df-d0dd-5eb7-207d" name="Battleships" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false">
+        <categoryLink id="33df-d0dd-5eb7-207d" name="Battleship" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false">
           <modifiers>
             <modifier type="increment" field="b915-f846-abba-76e9" value="1">
               <conditions>
-                <condition field="points" scope="force" value="1000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="atLeast"/>
+                <condition field="points" scope="force" value="1000" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="atLeast"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="b915-f846-abba-76e9" value="1">
               <conditions>
-                <condition field="points" scope="force" value="3000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="atLeast"/>
+                <condition field="points" scope="force" value="3000" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="atLeast"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="b915-f846-abba-76e9" value="1">
               <conditions>
-                <condition field="points" scope="force" value="2000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="atLeast"/>
+                <condition field="points" scope="force" value="2000" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b915-f846-abba-76e9" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b915-f846-abba-76e9" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="11d4-95d3-7cf8-f701" name="Escorts" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
+        <categoryLink id="11d4-95d3-7cf8-f701" name="Escort" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
         <categoryLink id="ce39-0d4e-a405-bcc3" name="Special" hidden="false" targetId="5370656369616c23232344415441232323" primary="false"/>
-        <categoryLink id="fa4d-46fb-85f9-42d0" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="false">
+        <categoryLink id="fa4d-46fb-85f9-42d0" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d2f-23a3-61cf-4344" type="max"/>
+            <constraint field="selections" scope="parent" value="12" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d2f-23a3-61cf-4344" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="5288-cc1e-a024-e60e" name="Grand Cruisers" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false"/>
-        <categoryLink id="25b0-a245-510e-d7a9" name="Heavy Cruisers" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
-        <categoryLink id="73a2-1e30-ad57-581f" name="Orbital Defences" hidden="false" targetId="90ac-0bee-0c90-be27" primary="false"/>
+        <categoryLink id="5288-cc1e-a024-e60e" name="Grand Cruiser" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false"/>
+        <categoryLink id="25b0-a245-510e-d7a9" name="Heavy Cruiser" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
+        <categoryLink id="73a2-1e30-ad57-581f" name="Orbital Defence" hidden="false" targetId="90ac-0bee-0c90-be27" primary="false"/>
         <categoryLink id="459a-cb2f-b8d1-cebb" name="Ordnance" hidden="false" targetId="e70d-1bf2-7ea2-276a" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="0335-3148-5471-abe3" name="Adeptus Mechanicus (unsupported)" hidden="false">
       <categoryLinks>
-        <categoryLink id="9ccd-7823-cddd-02c4" name="Fleet Commanders" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="false">
+        <categoryLink id="9ccd-7823-cddd-02c4" name="Fleet Commander" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="false">
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="6824-3500-b435-d5cb" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="6824-3500-b435-d5cb" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="71f5-c192-57cd-b9e5" name="Battleships" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false"/>
-        <categoryLink id="e778-89a0-454f-9ae5" name="Escorts" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
+        <categoryLink id="71f5-c192-57cd-b9e5" name="Battleship" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false"/>
+        <categoryLink id="e778-89a0-454f-9ae5" name="Escort" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
         <categoryLink id="2fcc-03b0-b127-e038" name="Special" hidden="false" targetId="5370656369616c23232344415441232323" primary="false"/>
-        <categoryLink id="d0c7-52f8-a421-2c47" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="false">
+        <categoryLink id="d0c7-52f8-a421-2c47" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false">
           <modifiers>
             <modifier type="increment" field="07ce-ab99-802e-7d78" value="3">
               <repeats>
-                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4361706974616c20536869707323232344415441232323" repeats="1" roundUp="false"/>
-                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="46e2-c9eb-27e7-172a" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4361706974616c20536869707323232344415441232323" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="46e2-c9eb-27e7-172a" repeats="1" roundUp="false"/>
               </repeats>
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="46e2-c9eb-27e7-172a" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="46e2-c9eb-27e7-172a" type="instanceOf"/>
-                    <condition field="selections" scope="4361706974616c20536869707323232344415441232323" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4361706974616c20536869707323232344415441232323" type="instanceOf"/>
+                    <condition field="selections" scope="46e2-c9eb-27e7-172a" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="46e2-c9eb-27e7-172a" type="instanceOf"/>
+                    <condition field="selections" scope="4361706974616c20536869707323232344415441232323" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4361706974616c20536869707323232344415441232323" type="instanceOf"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
             <modifier type="increment" field="07ce-ab99-802e-7d78" value="2">
               <repeats>
-                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cf79-82ee-ebe9-7ea3" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cf79-82ee-ebe9-7ea3" repeats="1" roundUp="false"/>
               </repeats>
               <conditions>
-                <condition field="selections" scope="cf79-82ee-ebe9-7ea3" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cf79-82ee-ebe9-7ea3" type="instanceOf"/>
+                <condition field="selections" scope="cf79-82ee-ebe9-7ea3" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cf79-82ee-ebe9-7ea3" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45e0-b6ff-173d-28b1" type="max"/>
-            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07ce-ab99-802e-7d78" type="min"/>
+            <constraint field="selections" scope="parent" value="15" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45e0-b6ff-173d-28b1" type="max"/>
+            <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07ce-ab99-802e-7d78" type="min"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="df73-00a8-8a21-18d4" name="Grand Cruisers" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false"/>
-        <categoryLink id="09a1-4767-b538-0486" name="Battlecruisers &amp; Heavy Cruisers" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
+        <categoryLink id="df73-00a8-8a21-18d4" name="Grand Cruiser" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false"/>
+        <categoryLink id="09a1-4767-b538-0486" name="Heavy Cruiser" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
         <categoryLink id="9e7c-00dd-06da-11fc" name="Ordnance" hidden="false" targetId="e70d-1bf2-7ea2-276a" primary="false"/>
-        <categoryLink id="0528-cc94-d408-08f8" name="Orbital Defences" hidden="false" targetId="90ac-0bee-0c90-be27" primary="false"/>
+        <categoryLink id="0528-cc94-d408-08f8" name="Orbital Defence" hidden="false" targetId="90ac-0bee-0c90-be27" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="eb02-283b-cb5e-e4ea" name="Battlefleet Cadia" publicationId="1bc8-5968-21c3-0f27" page="29" hidden="false">
@@ -351,64 +351,64 @@
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="0e8e-9b65-c823-e174" name="Fleet Commanders" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="false">
+        <categoryLink id="0e8e-9b65-c823-e174" name="Fleet Commander" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="false">
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="cd3a-8ddf-548b-9e7c" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="cd3a-8ddf-548b-9e7c" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="096b-a346-07d7-b61b" name="Escorts" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
+        <categoryLink id="096b-a346-07d7-b61b" name="Escort" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
         <categoryLink id="ad66-0b9d-89d9-9a2d" name="Special" hidden="false" targetId="5370656369616c23232344415441232323" primary="false"/>
-        <categoryLink id="a0cf-afca-c5e0-21d4" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="false">
+        <categoryLink id="a0cf-afca-c5e0-21d4" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d20-6826-3f6c-fd75" type="max"/>
-            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="091d-f696-6575-91d2" type="min"/>
+            <constraint field="selections" scope="parent" value="12" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d20-6826-3f6c-fd75" type="max"/>
+            <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="091d-f696-6575-91d2" type="min"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="2ea0-473d-7901-e797" name="Orbital Defences" hidden="false" targetId="90ac-0bee-0c90-be27" primary="false"/>
+        <categoryLink id="2ea0-473d-7901-e797" name="Orbital Defence" hidden="false" targetId="90ac-0bee-0c90-be27" primary="false"/>
         <categoryLink id="7495-b8d1-89c6-e734" name="Ordnance" hidden="false" targetId="e70d-1bf2-7ea2-276a" primary="false"/>
         <categoryLink id="e8f8-c363-1f78-552b" name="Grand Cruiser" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false">
           <modifiers>
-            <modifier type="increment" field="a3b9-6c4e-b72e-98b0" value="1.0">
+            <modifier type="increment" field="a3b9-6c4e-b72e-98b0" value="1">
               <repeats>
-                <repeat field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1042-e458-4e02-a537" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="force" value="3" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1042-e458-4e02-a537" repeats="1" roundUp="false"/>
               </repeats>
               <conditions>
-                <condition field="selections" scope="force" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1042-e458-4e02-a537" type="greaterThan"/>
+                <condition field="selections" scope="force" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1042-e458-4e02-a537" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3b9-6c4e-b72e-98b0" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3b9-6c4e-b72e-98b0" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="b565-afdf-3580-4362" name="Battlecruiser" hidden="false" targetId="b041-ef69-0039-d535" primary="false">
           <modifiers>
-            <modifier type="increment" field="fca8-986f-b3a9-51af" value="1.0">
+            <modifier type="increment" field="fca8-986f-b3a9-51af" value="1">
               <repeats>
-                <repeat field="selections" scope="force" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e0c6-bde4-7055-1e6e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="force" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e0c6-bde4-7055-1e6e" repeats="1" roundUp="false"/>
               </repeats>
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e0c6-bde4-7055-1e6e" type="greaterThan"/>
+                <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e0c6-bde4-7055-1e6e" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fca8-986f-b3a9-51af" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fca8-986f-b3a9-51af" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="b66c-239b-6932-c3b6" name="Battleships" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false">
+        <categoryLink id="b66c-239b-6932-c3b6" name="Battleship" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false">
           <modifiers>
-            <modifier type="increment" field="3a9a-9424-e5f4-ca8c" value="1.0">
+            <modifier type="increment" field="3a9a-9424-e5f4-ca8c" value="1">
               <repeats>
-                <repeat field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1042-e458-4e02-a537" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="force" value="3" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1042-e458-4e02-a537" repeats="1" roundUp="false"/>
               </repeats>
               <conditions>
-                <condition field="selections" scope="force" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1042-e458-4e02-a537" type="greaterThan"/>
+                <condition field="selections" scope="force" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1042-e458-4e02-a537" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a9a-9424-e5f4-ca8c" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a9a-9424-e5f4-ca8c" type="max"/>
           </constraints>
         </categoryLink>
       </categoryLinks>
@@ -416,107 +416,107 @@
     <forceEntry id="82c2-f360-d49f-cb84" name="Space Marines Dominion (unsupported)" hidden="false">
       <comment>Should be in Space Marines Faction</comment>
       <categoryLinks>
-        <categoryLink id="023d-03cc-bf6f-782e" name="Fleet Commanders" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="false">
+        <categoryLink id="023d-03cc-bf6f-782e" name="Fleet Commander" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="false">
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="1cdb-4280-5390-82c6" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="1cdb-4280-5390-82c6" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="8570-0e90-0cc6-b893" name="Battleships" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false">
+        <categoryLink id="8570-0e90-0cc6-b893" name="Battleship" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false">
           <modifiers>
             <modifier type="increment" field="e115-e045-44fc-5eef" value="1">
               <conditions>
-                <condition field="points" scope="force" value="1000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="atLeast"/>
+                <condition field="points" scope="force" value="1000" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="atLeast"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="e115-e045-44fc-5eef" value="1">
               <conditions>
-                <condition field="points" scope="force" value="3000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="atLeast"/>
+                <condition field="points" scope="force" value="3000" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="atLeast"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="e115-e045-44fc-5eef" value="1">
               <conditions>
-                <condition field="points" scope="force" value="2000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="atLeast"/>
+                <condition field="points" scope="force" value="2000" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e115-e045-44fc-5eef" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e115-e045-44fc-5eef" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="50f0-fe1d-9d90-debc" name="Escorts" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
+        <categoryLink id="50f0-fe1d-9d90-debc" name="Escort" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
         <categoryLink id="0c67-4ec4-fb32-c95e" name="Special" hidden="false" targetId="5370656369616c23232344415441232323" primary="false"/>
-        <categoryLink id="db99-eed1-5e72-2237" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="false">
+        <categoryLink id="db99-eed1-5e72-2237" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2772-d67b-c6c3-d6a2" type="max"/>
+            <constraint field="selections" scope="parent" value="12" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2772-d67b-c6c3-d6a2" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="21f3-4553-a823-c293" name="Grand Cruisers" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false"/>
-        <categoryLink id="c10d-3a6d-a1a5-5548" name="Heavy Cruisers" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
+        <categoryLink id="21f3-4553-a823-c293" name="Grand Cruiser" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false"/>
+        <categoryLink id="c10d-3a6d-a1a5-5548" name="Heavy Cruiser" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
         <categoryLink id="2851-c0f1-3f55-5525" name="Ordnance" hidden="false" targetId="e70d-1bf2-7ea2-276a" primary="false"/>
-        <categoryLink id="46aa-ca28-8d6e-4a42" name="Orbital Defences" hidden="false" targetId="90ac-0bee-0c90-be27" primary="false"/>
+        <categoryLink id="46aa-ca28-8d6e-4a42" name="Orbital Defence" hidden="false" targetId="90ac-0bee-0c90-be27" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="70d0-c8dc-b8b6-a258" name="Wolf Pack Human Pirates" hidden="false">
       <categoryLinks>
-        <categoryLink id="fab8-c38f-061f-2e3b" name="Fleet Commanders" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="false">
+        <categoryLink id="fab8-c38f-061f-2e3b" name="Fleet Commander" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="false">
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="86c4-7df9-ff09-72d5" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="86c4-7df9-ff09-72d5" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="f87d-daaa-090e-1cc6" name="Escorts" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
+        <categoryLink id="f87d-daaa-090e-1cc6" name="Escort" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
         <categoryLink id="1c76-436c-e6b9-e2d2" name="Special" hidden="false" targetId="5370656369616c23232344415441232323" primary="false"/>
-        <categoryLink id="da14-a613-d31e-00f7" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
-        <categoryLink id="c32a-51d6-f08e-c491" name="Orbital Defences" hidden="false" targetId="90ac-0bee-0c90-be27" primary="false"/>
+        <categoryLink id="da14-a613-d31e-00f7" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
+        <categoryLink id="c32a-51d6-f08e-c491" name="Orbital Defence" hidden="false" targetId="90ac-0bee-0c90-be27" primary="false"/>
         <categoryLink id="2923-49d0-9291-488f" name="Ordnance" hidden="false" targetId="e70d-1bf2-7ea2-276a" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="bcf5-810c-d5b8-b7da" name="The Emperor&apos;s Inquisition (unsupported)" publicationId="5766-7751-d146-0800" page="51" hidden="false">
       <comment>This should be independant</comment>
       <categoryLinks>
-        <categoryLink id="955b-d296-9bb8-aa7b" name="Fleet Commanders" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="false">
+        <categoryLink id="955b-d296-9bb8-aa7b" name="Fleet Commander" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="false">
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="d3bb-8eb2-89ee-aa93" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="d3bb-8eb2-89ee-aa93" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="778c-9d9d-d0d8-1fb2" name="Battleships" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false">
+        <categoryLink id="778c-9d9d-d0d8-1fb2" name="Battleship" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false">
           <modifiers>
             <modifier type="increment" field="2a6a-c452-024e-67da" value="1">
               <conditions>
-                <condition field="points" scope="force" value="1000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="atLeast"/>
+                <condition field="points" scope="force" value="1000" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="atLeast"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="2a6a-c452-024e-67da" value="1">
               <conditions>
-                <condition field="points" scope="force" value="3000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="atLeast"/>
+                <condition field="points" scope="force" value="3000" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="atLeast"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="2a6a-c452-024e-67da" value="1">
               <conditions>
-                <condition field="points" scope="force" value="2000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="atLeast"/>
+                <condition field="points" scope="force" value="2000" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a6a-c452-024e-67da" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a6a-c452-024e-67da" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="0f24-2e93-3314-9a64" name="Escorts" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
+        <categoryLink id="0f24-2e93-3314-9a64" name="Escort" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
         <categoryLink id="18ac-fc66-d6ed-679e" name="Special" hidden="false" targetId="5370656369616c23232344415441232323" primary="false"/>
-        <categoryLink id="5c7a-05bb-4333-b328" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="false">
+        <categoryLink id="5c7a-05bb-4333-b328" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee3c-d507-4d90-99a4" type="max"/>
+            <constraint field="selections" scope="parent" value="10" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee3c-d507-4d90-99a4" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="ebca-d24d-85cf-89d8" name="Grand Cruisers" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false"/>
-        <categoryLink id="2f58-41a9-bc40-8670" name="Heavy Cruisers" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
-        <categoryLink id="8e17-bd2c-def3-dc9d" name="Orbital Defences" hidden="false" targetId="90ac-0bee-0c90-be27" primary="false"/>
+        <categoryLink id="ebca-d24d-85cf-89d8" name="Grand Cruiser" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false"/>
+        <categoryLink id="2f58-41a9-bc40-8670" name="Heavy Cruiser" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
+        <categoryLink id="8e17-bd2c-def3-dc9d" name="Orbital Defence" hidden="false" targetId="90ac-0bee-0c90-be27" primary="false"/>
         <categoryLink id="fa32-3fea-4866-f482" name="Ordnance" hidden="false" targetId="e70d-1bf2-7ea2-276a" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="e874-e62b-1c36-7aec" name="Battlefleet Bakka, Saviors of Maccrage" publicationId="5766-7751-d146-0800" page="32" hidden="false">
       <categoryLinks>
         <categoryLink id="b4d6-160e-fad8-8a9d" name="Fleet Commander" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="false"/>
-        <categoryLink id="6efe-d796-a7f3-360e" name="Escorts" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
+        <categoryLink id="6efe-d796-a7f3-360e" name="Escort" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
         <categoryLink id="da63-1233-5447-df84" name="Special" hidden="false" targetId="5370656369616c23232344415441232323" primary="false"/>
         <categoryLink id="e872-a921-8e0d-cab6" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
         <categoryLink id="7baa-5f86-f6a4-32aa" name="Ordnance" hidden="false" targetId="e70d-1bf2-7ea2-276a" primary="false"/>
@@ -531,20 +531,20 @@
     <selectionEntry id="56cb8f0d-fd9f-40a2-9ee5-9353341ab66b" name="Defiant Class Light Cruiser" publicationId="1bc8-5968-21c3-0f27" page="19" hidden="true" collective="false" import="true" type="model">
       <comment>dropped to 120 on pg 19 2010 FAQ</comment>
       <modifiers>
-        <modifier type="increment" field="points" value="35.0">
+        <modifier type="increment" field="points" value="35">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -555,37 +555,37 @@
           <modifiers>
             <modifier type="set" field="5475726e7323232344415441232323" value="45°">
               <conditions>
-                <condition field="selections" scope="56cb8f0d-fd9f-40a2-9ee5-9353341ab66b" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="ef3d-da2a-cd0d-7e75" type="equalTo"/>
+                <condition field="selections" scope="56cb8f0d-fd9f-40a2-9ee5-9353341ab66b" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="ef3d-da2a-cd0d-7e75" type="equalTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="41726d6f757223232344415441232323" value="6+">
               <conditions>
-                <condition field="selections" scope="56cb8f0d-fd9f-40a2-9ee5-9353341ab66b" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="ef3d-da2a-cd0d-7e75" type="equalTo"/>
+                <condition field="selections" scope="56cb8f0d-fd9f-40a2-9ee5-9353341ab66b" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="ef3d-da2a-cd0d-7e75" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">6</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">6</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">90°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">2</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">2</characteristic>
           </characteristics>
         </profile>
         <profile id="92ea-6220-e3d9-80ce" name="Prow Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
         <profile id="a459-874e-0675-8d24" name="Port Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <modifiers>
             <modifier type="append" field="52616e67652f537065656423232344415441232323" value="Torpedo Bomber: 20cm (STR 2)">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beba-9f13-d04b-6ad6" type="instanceOf"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beba-9f13-d04b-6ad6" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -593,14 +593,14 @@
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Furies: 30cm
 Starhawks: 20cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1 Squadron</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
         <profile id="a44f-1b56-eb3e-bb02" name="Starboard Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <modifiers>
             <modifier type="append" field="52616e67652f537065656423232344415441232323" value="Torpedo Bomber: 20cm (STR 2)">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beba-9f13-d04b-6ad6" type="instanceOf"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beba-9f13-d04b-6ad6" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -608,7 +608,7 @@ Starhawks: 20cm</characteristic>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Furies: 30cm
 Starhawks: 20cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1 Squadron</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -616,24 +616,24 @@ Starhawks: 20cm</characteristic>
         <infoLink id="d704-8333-63fb-437e" name="Defensive Corridors" hidden="false" targetId="ad35-5fda-fa0b-e885" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="e02b-f595-f396-1b7c" name="New CategoryLink" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
+        <categoryLink id="e02b-f595-f396-1b7c" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
         <categoryLink id="61fd-14f3-bd76-abdf" name="CV" hidden="false" targetId="e0c6-bde4-7055-1e6e" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="fa28-6af7-3a4d-829d" name="Options" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afd7-af96-2a35-7dbc" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af1f-2962-ca5c-5d50" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afd7-af96-2a35-7dbc" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af1f-2962-ca5c-5d50" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="ef3d-da2a-cd0d-7e75" name="Extra Armor" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4a7c-14d8-1f9c-7b13" name="Standard" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -646,7 +646,7 @@ Starhawks: 20cm</characteristic>
             <modifier type="increment" field="points" value="10"/>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -654,7 +654,7 @@ Starhawks: 20cm</characteristic>
         <entryLink id="b801-9154-fe0a-344b" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="120.0"/>
+        <cost name="pts" typeId="points" value="120"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e85f290e-c2d4-4737-ae0d-7b3099a761fe" name="Imperial Endeavour Class Light Cruiser" publicationId="1bc8-5968-21c3-0f27" page="18" hidden="true" collective="false" import="true" type="model">
@@ -662,18 +662,18 @@ Starhawks: 20cm</characteristic>
       <modifiers>
         <modifier type="increment" field="points" value="35">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -684,51 +684,51 @@ Starhawks: 20cm</characteristic>
           <modifiers>
             <modifier type="set" field="5475726e7323232344415441232323" value="45°">
               <conditions>
-                <condition field="selections" scope="e85f290e-c2d4-4737-ae0d-7b3099a761fe" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="f3bd-e25e-aeca-f4a5" type="equalTo"/>
+                <condition field="selections" scope="e85f290e-c2d4-4737-ae0d-7b3099a761fe" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="f3bd-e25e-aeca-f4a5" type="equalTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="41726d6f757223232344415441232323" value="6+">
               <conditions>
-                <condition field="selections" scope="e85f290e-c2d4-4737-ae0d-7b3099a761fe" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="f3bd-e25e-aeca-f4a5" type="equalTo"/>
+                <condition field="selections" scope="e85f290e-c2d4-4737-ae0d-7b3099a761fe" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="f3bd-e25e-aeca-f4a5" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">6</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">6</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">90°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">2</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">2</characteristic>
           </characteristics>
         </profile>
         <profile id="ed43-3fc0-239f-f3fa" name="Prow Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
         <profile id="5eda-aa4a-744e-e9e0" name="Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="b455-07c4-b794-6ad8" name="Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="3952-2dd9-ee08-b2c5" name="Prow Torpedoes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -737,13 +737,13 @@ Starhawks: 20cm</characteristic>
         <infoLink id="4a9f-515c-af26-86d2" name="Torpedoes" hidden="false" targetId="8103-25d2-5412-2542" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="24dd-8ee7-623b-6d87" name="New CategoryLink" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
+        <categoryLink id="24dd-8ee7-623b-6d87" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
         <categoryLink id="deb1-d0bb-bffa-45a1" name="CV" hidden="false" targetId="e0c6-bde4-7055-1e6e" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="d765-f02f-014a-4038" name="Power Ram" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17f4-eb85-04d4-6b1e" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17f4-eb85-04d4-6b1e" type="max"/>
           </constraints>
           <profiles>
             <profile id="29e0-4595-0807-f786" name="Power Ram" publicationId="11f0-17d1-e4d2-1018" page="115" hidden="false" typeId="5a49-6569-78e9-a35c" typeName="Special Rule">
@@ -753,25 +753,25 @@ Starhawks: 20cm</characteristic>
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
+            <cost name="pts" typeId="points" value="5"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="49e5-979d-dda5-8a49" name="Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="d77e-35b8-0054-2afd">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a59c-7de7-0f63-fcd5" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="72fc-8adf-dd0b-47c4" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a59c-7de7-0f63-fcd5" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="72fc-8adf-dd0b-47c4" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="f3bd-e25e-aeca-f4a5" name="Extra Armor" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d77e-35b8-0054-2afd" name="Standard" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -782,7 +782,7 @@ Starhawks: 20cm</characteristic>
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
               </conditions>
             </modifier>
             <modifier type="decrement" field="points" value="10"/>
@@ -793,17 +793,17 @@ Starhawks: 20cm</characteristic>
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91bc-d6de-122f-a42d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91bc-d6de-122f-a42d" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="110.0"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d65cfd13-349b-42f9-a853-96ff13660399" name="Imperial Endurance Class Light Cruiser" publicationId="1bc8-5968-21c3-0f27" page="18" hidden="true" collective="false" import="true" type="model">
@@ -811,18 +811,18 @@ Starhawks: 20cm</characteristic>
       <modifiers>
         <modifier type="increment" field="points" value="35">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -833,51 +833,51 @@ Starhawks: 20cm</characteristic>
           <modifiers>
             <modifier type="set" field="5475726e7323232344415441232323" value="45°">
               <conditions>
-                <condition field="selections" scope="d65cfd13-349b-42f9-a853-96ff13660399" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="0eaa-df2a-ea28-a183" type="equalTo"/>
+                <condition field="selections" scope="d65cfd13-349b-42f9-a853-96ff13660399" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="0eaa-df2a-ea28-a183" type="equalTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="41726d6f757223232344415441232323" value="6+">
               <conditions>
-                <condition field="selections" scope="d65cfd13-349b-42f9-a853-96ff13660399" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="0eaa-df2a-ea28-a183" type="equalTo"/>
+                <condition field="selections" scope="d65cfd13-349b-42f9-a853-96ff13660399" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="0eaa-df2a-ea28-a183" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">6</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">6</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">90°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">2</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">2</characteristic>
           </characteristics>
         </profile>
         <profile id="b48f-62a2-5e9b-e346" name="Prow Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
         <profile id="4b63-16ac-c8ba-7bab" name="Prow Torpedoes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
           </characteristics>
         </profile>
         <profile id="85c9-eb6d-9d94-b225" name="Port Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="faf9-9d05-edd5-0096" name="Starboard Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -886,13 +886,13 @@ Starhawks: 20cm</characteristic>
         <infoLink id="dacd-6cac-97cd-08b4" name="Torpedoes" hidden="false" targetId="8103-25d2-5412-2542" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="b66a-312d-ad61-b900" name="New CategoryLink" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
+        <categoryLink id="b66a-312d-ad61-b900" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
         <categoryLink id="de35-41e1-517a-472f" name="CV" hidden="false" targetId="e0c6-bde4-7055-1e6e" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="0274-b592-692e-f184" name="Power Ram" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba18-6745-71e6-b8dc" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba18-6745-71e6-b8dc" type="max"/>
           </constraints>
           <profiles>
             <profile id="a09e-d5e0-c4e6-270c" name="Power Ram" publicationId="11f0-17d1-e4d2-1018" page="115" hidden="false" typeId="5a49-6569-78e9-a35c" typeName="Special Rule">
@@ -902,36 +902,36 @@ Starhawks: 20cm</characteristic>
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
+            <cost name="pts" typeId="points" value="5"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="904c-136b-cc23-998d" name="Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="aee1-4edf-cb66-3fc2">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ede-04cf-18d5-9034" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d13-8721-e0c8-aed7" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ede-04cf-18d5-9034" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d13-8721-e0c8-aed7" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="0eaa-df2a-ea28-a183" name="Extra Armor" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aee1-4edf-cb66-3fc2" name="Standard" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="d0ad-0e4c-a54b-4cf4" name="Refited Torpedoes" hidden="true" collective="false" import="true" targetId="5d45-6ad5-d4cc-8570" type="selectionEntry">
+        <entryLink id="d0ad-0e4c-a54b-4cf4" name="Refited Torpedoes (p 156 of BFG Armada)" hidden="true" collective="false" import="true" targetId="5d45-6ad5-d4cc-8570" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
               </conditions>
             </modifier>
             <modifier type="decrement" field="points" value="10"/>
@@ -940,7 +940,7 @@ Starhawks: 20cm</characteristic>
         <entryLink id="b039-e212-6c38-6403" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="110.0"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e670be5a-3aad-4eba-9e5e-2b79130c13b6" name="Fleet Commander" page="0" hidden="true" collective="false" import="true" type="upgrade">
@@ -949,62 +949,72 @@ Starhawks: 20cm</characteristic>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed8-4a6a-2f2b-833d" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed8-4a6a-2f2b-833d" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="increment" field="69a8-3aa2-17c6-0968" value="1">
           <conditions>
-            <condition field="points" scope="force" value="749.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="greaterThan"/>
+            <condition type="greaterThan" value="749" field="points" scope="force" childId="any" shared="true" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+          </conditions>
+        </modifier>
+        <modifier type="decrement" value="1" field="69a8-3aa2-17c6-0968">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="466c65657420436f6d6d616e6465727323232344415441232323" childId="4282-4e4d-6688-ba0c" shared="true" includeChildSelections="true" includeChildForces="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="decrement" value="1" field="maxInRoster">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="466c65657420436f6d6d616e6465727323232344415441232323" childId="4282-4e4d-6688-ba0c" shared="true" includeChildSelections="true" includeChildForces="true"/>
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69a8-3aa2-17c6-0968" type="min"/>
+        <constraint field="selections" scope="roster" value="1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69a8-3aa2-17c6-0968" type="min"/>
       </constraints>
       <profiles>
         <profile id="24de-25a9-5cfc-975d" name="Fleet Commander" publicationId="11f0-17d1-e4d2-1018" page="115" hidden="false" typeId="436f6d6d616e64657223232344415441232323" typeName="Commander">
           <modifiers>
             <modifier type="increment" field="4c65616465727368697023232344415441232323" value="1">
               <conditions>
-                <condition field="selections" scope="e670be5a-3aad-4eba-9e5e-2b79130c13b6" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1a1ebb83-bf55-4fc3-8aca-e3b3c733369d" type="equalTo"/>
+                <condition field="selections" scope="e670be5a-3aad-4eba-9e5e-2b79130c13b6" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1a1ebb83-bf55-4fc3-8aca-e3b3c733369d" type="equalTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="4c65616465727368697023232344415441232323" value="2">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="e670be5a-3aad-4eba-9e5e-2b79130c13b6" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bb453fc8-379f-49ca-8030-2c3456c729a0" type="equalTo"/>
-                    <condition field="selections" scope="e670be5a-3aad-4eba-9e5e-2b79130c13b6" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="375c-4f20-011c-693d" type="equalTo"/>
+                    <condition field="selections" scope="e670be5a-3aad-4eba-9e5e-2b79130c13b6" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bb453fc8-379f-49ca-8030-2c3456c729a0" type="equalTo"/>
+                    <condition field="selections" scope="e670be5a-3aad-4eba-9e5e-2b79130c13b6" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="375c-4f20-011c-693d" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
             <modifier type="increment" field="52652d726f6c6c7323232344415441232323" value="1">
               <conditions>
-                <condition field="selections" scope="e670be5a-3aad-4eba-9e5e-2b79130c13b6" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="035e-33cd-0111-9ac2" type="equalTo"/>
+                <condition field="selections" scope="e670be5a-3aad-4eba-9e5e-2b79130c13b6" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="035e-33cd-0111-9ac2" type="equalTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="52652d726f6c6c7323232344415441232323" value="2">
               <conditions>
-                <condition field="selections" scope="e670be5a-3aad-4eba-9e5e-2b79130c13b6" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3306-d205-6a51-6546" type="equalTo"/>
+                <condition field="selections" scope="e670be5a-3aad-4eba-9e5e-2b79130c13b6" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3306-d205-6a51-6546" type="equalTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="52652d726f6c6c7323232344415441232323" value="3">
               <conditions>
-                <condition field="selections" scope="e670be5a-3aad-4eba-9e5e-2b79130c13b6" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3b86-8b3f-9839-a009" type="equalTo"/>
+                <condition field="selections" scope="e670be5a-3aad-4eba-9e5e-2b79130c13b6" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3b86-8b3f-9839-a009" type="equalTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="52652d726f6c6c7323232344415441232323" value="1">
               <conditions>
-                <condition field="selections" scope="e670be5a-3aad-4eba-9e5e-2b79130c13b6" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="375c-4f20-011c-693d" type="equalTo"/>
+                <condition field="selections" scope="e670be5a-3aad-4eba-9e5e-2b79130c13b6" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="375c-4f20-011c-693d" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -1016,46 +1026,46 @@ Starhawks: 20cm</characteristic>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="e670be5a-3aad-4eba-9e5e-2b79130c13b6-466c65657420436f6d6d616e6465727323232344415441232323" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="true"/>
+        <categoryLink id="e670be5a-3aad-4eba-9e5e-2b79130c13b6-466c65657420436f6d6d616e6465727323232344415441232323" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="true" name="Fleet Commander"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="d10c8575-754d-4a56-b4b7-3fd2f09fb82a" name="Rank" hidden="false" collective="false" import="true" defaultSelectionEntryId="2f63e8ff-5632-43eb-9434-d6749e7115a0">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="2f63e8ff-5632-43eb-9434-d6749e7115a0" name="Fleet Admiral Ldr 8" page="0" hidden="false" collective="false" import="true" type="unit">
               <constraints>
-                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+                <constraint field="selections" scope="roster" value="1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
               </constraints>
               <categoryLinks>
-                <categoryLink id="2f63e8ff-5632-43eb-9434-d6749e7115a0-466c65657420436f6d6d616e6465727323232344415441232323" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="true"/>
+                <categoryLink id="2f63e8ff-5632-43eb-9434-d6749e7115a0-466c65657420436f6d6d616e6465727323232344415441232323" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="true" name="Fleet Commander"/>
               </categoryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="50.0"/>
+                <cost name="pts" typeId="points" value="50"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bb453fc8-379f-49ca-8030-2c3456c729a0" name="Solar Admiral Ldr 10" page="0" hidden="false" collective="false" import="true" type="unit">
               <constraints>
-                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+                <constraint field="selections" scope="roster" value="1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
               </constraints>
               <categoryLinks>
-                <categoryLink id="bb453fc8-379f-49ca-8030-2c3456c729a0-466c65657420436f6d6d616e6465727323232344415441232323" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="true"/>
+                <categoryLink id="bb453fc8-379f-49ca-8030-2c3456c729a0-466c65657420436f6d6d616e6465727323232344415441232323" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="true" name="Fleet Commander"/>
               </categoryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="150.0"/>
+                <cost name="pts" typeId="points" value="150"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1a1ebb83-bf55-4fc3-8aca-e3b3c733369d" name="Admiral Ldr 9" page="0" hidden="false" collective="false" import="true" type="unit">
               <constraints>
-                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+                <constraint field="selections" scope="roster" value="1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
               </constraints>
               <categoryLinks>
-                <categoryLink id="1a1ebb83-bf55-4fc3-8aca-e3b3c733369d-466c65657420436f6d6d616e6465727323232344415441232323" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="true"/>
+                <categoryLink id="1a1ebb83-bf55-4fc3-8aca-e3b3c733369d-466c65657420436f6d6d616e6465727323232344415441232323" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="true" name="Fleet Commander"/>
               </categoryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="100.0"/>
+                <cost name="pts" typeId="points" value="100"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8ff6f2a1-fc73-4742-a7d0-02b5d984c443" name="Master of the Fleet" page="0" hidden="true" collective="false" import="true" type="unit">
@@ -1064,43 +1074,43 @@ Starhawks: 20cm</characteristic>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6c1-3b56-fa5c-ebaa" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6c1-3b56-fa5c-ebaa" type="max"/>
               </constraints>
               <categoryLinks>
-                <categoryLink id="8ff6f2a1-fc73-4742-a7d0-02b5d984c443-466c65657420436f6d6d616e6465727323232344415441232323" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="true"/>
+                <categoryLink id="8ff6f2a1-fc73-4742-a7d0-02b5d984c443-466c65657420436f6d6d616e6465727323232344415441232323" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="true" name="Fleet Commander"/>
               </categoryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="50.0"/>
+                <cost name="pts" typeId="points" value="50"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="375c-4f20-011c-693d" name="Lord Admiral Rath Ldr 10" publicationId="5766-7751-d146-0800" page="36" hidden="true" collective="false" import="true" type="unit">
+            <selectionEntry id="375c-4f20-011c-693d" name="Lord Admiral Rath Ldr 10" publicationId="5766-7751-d146-0800" page="36" hidden="true" collective="false" import="true" type="unit" flatten="false" collapsible="false">
               <modifiers>
-                <modifier type="set" field="hidden" value="false">
+                <modifier type="set" field="hidden" value="true">
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
-                <modifier type="increment" field="0a10-cbdd-a0ae-ea8e" value="1.0">
+                <modifier type="increment" field="0a10-cbdd-a0ae-ea8e" value="1">
                   <conditions>
-                    <condition field="points" scope="roster" value="1499.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="greaterThan"/>
+                    <condition field="points" scope="roster" value="1499" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="greaterThan"/>
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a10-cbdd-a0ae-ea8e" type="max"/>
+                <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a10-cbdd-a0ae-ea8e" type="max"/>
               </constraints>
               <rules>
                 <rule id="ea79-84d2-e1fc-e95e" name="Lord Zaccarius Rath Ldr 10" publicationId="5766-7751-d146-0800" page="36" hidden="false">
@@ -1108,10 +1118,10 @@ Starhawks: 20cm</characteristic>
                 </rule>
               </rules>
               <categoryLinks>
-                <categoryLink id="f7b2-316a-00fd-f4ec" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="true"/>
+                <categoryLink id="f7b2-316a-00fd-f4ec" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="true" name="Fleet Commander"/>
               </categoryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="200.0"/>
+                <cost name="pts" typeId="points" value="200"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1122,60 +1132,60 @@ Starhawks: 20cm</characteristic>
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2f63e8ff-5632-43eb-9434-d6749e7115a0" type="instanceOf"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bb453fc8-379f-49ca-8030-2c3456c729a0" type="instanceOf"/>
+                    <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2f63e8ff-5632-43eb-9434-d6749e7115a0" type="instanceOf"/>
+                    <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bb453fc8-379f-49ca-8030-2c3456c729a0" type="instanceOf"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1221-5ae3-c9d3-3a34" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1221-5ae3-c9d3-3a34" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="3b86-8b3f-9839-a009" name="3 Extra Re-Rolls" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="decrement" field="points" value="75">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ff6f2a1-fc73-4742-a7d0-02b5d984c443" type="instanceOf"/>
+                    <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ff6f2a1-fc73-4742-a7d0-02b5d984c443" type="instanceOf"/>
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5129-8fcc-b7c4-686b" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5129-8fcc-b7c4-686b" type="max"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="points" value="150.0"/>
+                <cost name="pts" typeId="points" value="150"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="035e-33cd-0111-9ac2" name="1 Extra Re-Roll" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2ec0-b1d0-1825-d1ab" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2ec0-b1d0-1825-d1ab" type="max"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="points" value="25.0"/>
+                <cost name="pts" typeId="points" value="25"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3306-d205-6a51-6546" name="2 Extra Re-Rolls" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="decrement" field="points" value="25">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ff6f2a1-fc73-4742-a7d0-02b5d984c443" type="instanceOf"/>
+                    <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ff6f2a1-fc73-4742-a7d0-02b5d984c443" type="instanceOf"/>
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8791-5643-5ac4-381f" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8791-5643-5ac4-381f" type="max"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="points" value="75.0"/>
+                <cost name="pts" typeId="points" value="75"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="fda1dcc0-ba47-45eb-add7-79fd56c576ad" name="Ramilies Class Star Fort" page="0" hidden="true" collective="false" import="true" type="model">
@@ -1184,46 +1194,46 @@ Starhawks: 20cm</characteristic>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7ed-4469-26d7-c75b" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7ed-4469-26d7-c75b" type="max"/>
       </constraints>
       <profiles>
         <profile id="dfbe-08f5-11a1-90e1" name="Ramilies Profile" publicationId="1bc8-5968-21c3-0f27" page="24" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Defence</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">12 per quadrant</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">0cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Defence</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">12 per quadrant</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">0cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">0°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">4 per quadrant</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">4 per quadrant</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">4 per quadrant</characteristic>
           </characteristics>
         </profile>
         <profile id="f636-9e45-6007-7691" name="Quadrant Weapons Battery (1 per Quadrant)" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">12</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Quadrant</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Quadrant</characteristic>
           </characteristics>
         </profile>
         <profile id="fff4-2be4-8e0e-d3a1" name="Basilica Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">All Round</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">All Round</characteristic>
           </characteristics>
         </profile>
         <profile id="adec-2937-3f3c-40a5" name="Quadrant Lance Battery (1 per Quadrant)" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">5</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Quadrant</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Quadrant</characteristic>
           </characteristics>
         </profile>
         <profile id="cafc-c121-b357-0b01" name="Quadrant Launch Bays (1 per Quadrant)" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
@@ -1231,14 +1241,14 @@ Starhawks: 20cm</characteristic>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Fighters: 30cm
 Bombers: 20cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4 Squadrons</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
         <profile id="7317-8c81-7a61-46d1" name="Basilica Torpedo Silos" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">9</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">All Round</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">All Round</characteristic>
           </characteristics>
         </profile>
         <profile id="0454-2661-cdd9-a271" name="Special Rules" hidden="false" typeId="5a49-6569-78e9-a35c" typeName="Special Rule">
@@ -1251,14 +1261,14 @@ Bombers: 20cm</characteristic>
         <infoLink id="1f4e-1fe4-dba2-e70a" name="Torpedoes" hidden="false" targetId="8103-25d2-5412-2542" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="fda1dcc0-ba47-45eb-add7-79fd56c576ad-5370656369616c23232344415441232323" hidden="false" targetId="5370656369616c23232344415441232323" primary="true"/>
+        <categoryLink id="fda1dcc0-ba47-45eb-add7-79fd56c576ad-5370656369616c23232344415441232323" hidden="false" targetId="5370656369616c23232344415441232323" primary="true" name="Special"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="41b4-cb67-81b0-d761" name="Imperial Ordnance" hidden="false" collective="false" import="true" targetId="2da3-6f87-b676-1862" type="selectionEntryGroup"/>
         <entryLink id="c2cb-68d5-eef4-f80a" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="875.0"/>
+        <cost name="pts" typeId="points" value="875"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="83c2-8ca0-d80b-0911" name="Assault Strike Cruiser Variant" hidden="true" collective="false" import="true" type="model">
@@ -1267,7 +1277,7 @@ Bombers: 20cm</characteristic>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -1276,46 +1286,46 @@ Bombers: 20cm</characteristic>
       <profiles>
         <profile id="8cdf-4e79-42c4-bab3" name="Assault Strike Cruiser Variant" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">6</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">25cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">6</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">25cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">90°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">6+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">2</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">2</characteristic>
           </characteristics>
         </profile>
         <profile id="ff6b-d5dc-e54c-455f" name="Prow Bombardment Cannons" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
         <profile id="15e7-3080-fac5-2a71" name="Prow Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">20cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3 Thunderhawks</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
         <profile id="bb5f-fdd9-8834-fdb0" name="Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="112a-4b2a-aaf7-a3ad" name="Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="88d3-2332-4792-8f6c" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
+        <categoryLink id="88d3-2332-4792-8f6c" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
         <categoryLink id="d5fa-81a9-715b-033d" name="CV" hidden="false" targetId="e0c6-bde4-7055-1e6e" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -1323,7 +1333,7 @@ Bombers: 20cm</characteristic>
         <entryLink id="9942-2c3a-b61a-a316" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="165.0"/>
+        <cost name="pts" typeId="points" value="165"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d941-fa4c-ab47-bfd2" name="Devastator Strike Cruiser Variant" hidden="true" collective="false" import="true" type="model">
@@ -1332,7 +1342,7 @@ Bombers: 20cm</characteristic>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -1341,122 +1351,122 @@ Bombers: 20cm</characteristic>
       <profiles>
         <profile id="90d5-b429-7e9b-22ce" name="Devastator Strike Cruiser Variant" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">6</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">25cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">6</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">25cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">90°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">6+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">1</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">1</characteristic>
           </characteristics>
         </profile>
         <profile id="7463-3c51-7d5c-db9c" name="Prow Bombardment Cannons" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
         <profile id="ce21-0619-25d3-10bb" name="Prow orpedoes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
           </characteristics>
         </profile>
         <profile id="7b21-255f-909a-bb92" name="Prow Launch Bay" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">20cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3 Thunderhawks</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="da7c-0567-5e54-7106" name="New CategoryLink" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
+        <categoryLink id="da7c-0567-5e54-7106" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
         <categoryLink id="3ce7-f4e9-e087-44a9" name="CV" hidden="false" targetId="e0c6-bde4-7055-1e6e" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="abbf-d251-a6c0-0c47" name="Starboard Weapons" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d07a-3de0-568c-2d9d" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f01a-a855-fe45-05d1" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d07a-3de0-568c-2d9d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f01a-a855-fe45-05d1" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="833b-e127-89ef-3222" name="Lance" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e93-9a19-a663-7dd9" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e93-9a19-a663-7dd9" type="max"/>
               </constraints>
               <profiles>
                 <profile id="4be8-9a27-698e-f959" name="Starboard Lance" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5d4f-7e2e-9389-c00d" name="Weapons Batteries" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bba7-5890-f78e-e66d" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bba7-5890-f78e-e66d" type="max"/>
               </constraints>
               <profiles>
                 <profile id="f6a4-df2e-a904-7ecd" name="Starboard Weapons Batterie" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="eb8c-584c-e400-eb37" name="Port Weapons" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ef1-a993-6386-a3ce" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58a1-02a2-d794-5102" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ef1-a993-6386-a3ce" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58a1-02a2-d794-5102" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="26c8-accc-6aba-370f" name="Lance" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a161-cdeb-102d-d911" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a161-cdeb-102d-d911" type="max"/>
               </constraints>
               <profiles>
                 <profile id="4886-02cf-88ee-d626" name="Port Lance" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4a5e-e142-661c-fe23" name="Weapons Batteries" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57a2-d7ae-9139-a63a" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57a2-d7ae-9139-a63a" type="max"/>
               </constraints>
               <profiles>
                 <profile id="faf7-cbd8-2df5-546f" name="Port Weapons Batterie" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1467,28 +1477,28 @@ Bombers: 20cm</characteristic>
         <entryLink id="d777-872c-b57a-b8d8" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="160.0"/>
+        <cost name="pts" typeId="points" value="160"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3735-f8f9-adb1-e33e" name="Escort Squadron" page="0" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="c485-0adb-6886-2f38" hidden="false" targetId="4573636f72747323232344415441232323" primary="true"/>
+        <categoryLink id="c485-0adb-6886-2f38" hidden="false" targetId="4573636f72747323232344415441232323" primary="true" name="Escort"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="2fa7-ea2c-1d50-0b44" name="Escorts" hidden="false" collective="false" import="true">
           <modifiers>
-            <modifier type="set" field="b1a6-3f46-8430-8cb2" value="3.0">
+            <modifier type="set" field="b1a6-3f46-8430-8cb2" value="3">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3fca-d065-ff67-cd0d" type="atLeast"/>
+                <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3fca-d065-ff67-cd0d" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b1a6-3f46-8430-8cb2" type="min"/>
-            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9db1-ae3b-799b-44af" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b1a6-3f46-8430-8cb2" type="min"/>
+            <constraint field="selections" scope="parent" value="6" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9db1-ae3b-799b-44af" type="max"/>
           </constraints>
           <categoryLinks>
-            <categoryLink id="74ca-01a8-1c8b-19cb" name="Escorts" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
+            <categoryLink id="74ca-01a8-1c8b-19cb" name="Escort" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
           </categoryLinks>
           <selectionEntries>
             <selectionEntry id="f119-d902-6256-c50c" name="Gladius Frigate" publicationId="1bc8-5968-21c3-0f27" page="25" hidden="true" collective="false" import="true" type="unit">
@@ -1497,46 +1507,46 @@ Bombers: 20cm</characteristic>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7346-ab43-9438-149f" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82c2-f360-d49f-cb84" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5b8b-7613-df6a-8977" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6577-54b5-e6c6-11c5" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7346-ab43-9438-149f" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82c2-f360-d49f-cb84" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5b8b-7613-df6a-8977" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6577-54b5-e6c6-11c5" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d002-584f-3040-a348" type="max"/>
+                <constraint field="selections" scope="parent" value="6" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d002-584f-3040-a348" type="max"/>
               </constraints>
               <profiles>
                 <profile id="f291-ec1e-92a4-ee5d" name="Gladius Profile" publicationId="1bc8-5968-21c3-0f27" page="25" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
                   <characteristics>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Escort</characteristic>
-                    <characteristic name="Hits" typeId="4869747323232344415441232323">1</characteristic>
-                    <characteristic name="Speed" typeId="537065656423232344415441232323">30cm</characteristic>
+                    <characteristic name="Type" typeId="5.479706523232345e+27">Escort</characteristic>
+                    <characteristic name="Hits" typeId="4.869747323232344e+27">1</characteristic>
+                    <characteristic name="Speed" typeId="5.370656564232324e+29">30cm</characteristic>
                     <characteristic name="Turns" typeId="5475726e7323232344415441232323">90°</characteristic>
                     <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
                     <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-                    <characteristic name="Turrets" typeId="5475727265747323232344415441232323">1</characteristic>
+                    <characteristic name="Turrets" typeId="5.475727265747323e+33">1</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="e331-830f-bf72-8e88" name="Gladius Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="144e-1cf8-e355-5129" hidden="false" targetId="4573636f72747323232344415441232323" primary="true"/>
+                <categoryLink id="144e-1cf8-e355-5129" hidden="false" targetId="4573636f72747323232344415441232323" primary="true" name="Escort"/>
               </categoryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="45.0"/>
+                <cost name="pts" typeId="points" value="45"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c6c3-3872-a63b-80ea" name="Hunter Destroyer" publicationId="1bc8-5968-21c3-0f27" page="24" hidden="true" collective="false" import="true" type="unit">
@@ -1545,52 +1555,52 @@ Bombers: 20cm</characteristic>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7346-ab43-9438-149f" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82c2-f360-d49f-cb84" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6577-54b5-e6c6-11c5" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7346-ab43-9438-149f" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82c2-f360-d49f-cb84" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6577-54b5-e6c6-11c5" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="91d4-4f91-62aa-53f9" type="max"/>
+                <constraint field="selections" scope="parent" value="6" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="91d4-4f91-62aa-53f9" type="max"/>
               </constraints>
               <profiles>
                 <profile id="2359-4534-5ccd-47d2" name="Hunter Profile" publicationId="1bc8-5968-21c3-0f27" page="24" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
                   <characteristics>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Escort</characteristic>
-                    <characteristic name="Hits" typeId="4869747323232344415441232323">1</characteristic>
-                    <characteristic name="Speed" typeId="537065656423232344415441232323">35cm</characteristic>
+                    <characteristic name="Type" typeId="5.479706523232345e+27">Escort</characteristic>
+                    <characteristic name="Hits" typeId="4.869747323232344e+27">1</characteristic>
+                    <characteristic name="Speed" typeId="5.370656564232324e+29">35cm</characteristic>
                     <characteristic name="Turns" typeId="5475726e7323232344415441232323">90°</characteristic>
                     <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
                     <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-                    <characteristic name="Turrets" typeId="5475727265747323232344415441232323">1</characteristic>
+                    <characteristic name="Turrets" typeId="5.475727265747323e+33">1</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="9299-3692-de79-c232" name="Hunter Torpedoes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="1c60-7841-e53b-c970" name="Hunter Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="e6e1-cd41-ec4d-76f9" hidden="false" targetId="4573636f72747323232344415441232323" primary="true"/>
+                <categoryLink id="e6e1-cd41-ec4d-76f9" hidden="false" targetId="4573636f72747323232344415441232323" primary="true" name="Escort"/>
               </categoryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="40.0"/>
+                <cost name="pts" typeId="points" value="40"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="06b7-37b9-470d-8df9" name="Nova Frigate" publicationId="1bc8-5968-21c3-0f27" page="25" hidden="true" collective="false" import="true" type="unit">
@@ -1599,53 +1609,53 @@ Bombers: 20cm</characteristic>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7346-ab43-9438-149f" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82c2-f360-d49f-cb84" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5b8b-7613-df6a-8977" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6577-54b5-e6c6-11c5" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7346-ab43-9438-149f" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82c2-f360-d49f-cb84" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5b8b-7613-df6a-8977" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6577-54b5-e6c6-11c5" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="275b-584b-c6a0-c220" type="max"/>
+                <constraint field="selections" scope="parent" value="6" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="275b-584b-c6a0-c220" type="max"/>
               </constraints>
               <profiles>
                 <profile id="2008-c8b9-e83d-1f71" name="Nova Profile" publicationId="1bc8-5968-21c3-0f27" page="25" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
                   <characteristics>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Escort</characteristic>
-                    <characteristic name="Hits" typeId="4869747323232344415441232323">1</characteristic>
-                    <characteristic name="Speed" typeId="537065656423232344415441232323">35cm</characteristic>
+                    <characteristic name="Type" typeId="5.479706523232345e+27">Escort</characteristic>
+                    <characteristic name="Hits" typeId="4.869747323232344e+27">1</characteristic>
+                    <characteristic name="Speed" typeId="5.370656564232324e+29">35cm</characteristic>
                     <characteristic name="Turns" typeId="5475726e7323232344415441232323">90°</characteristic>
                     <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
                     <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-                    <characteristic name="Turrets" typeId="5475727265747323232344415441232323">1</characteristic>
+                    <characteristic name="Turrets" typeId="5.475727265747323e+33">1</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="4518-7ac3-3e02-5846" name="Nova Lance" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="4509-0b64-f3e1-b26a" name="Nova Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="e2e1-7709-5a17-d3b8" hidden="false" targetId="4573636f72747323232344415441232323" primary="true"/>
+                <categoryLink id="e2e1-7709-5a17-d3b8" hidden="false" targetId="4573636f72747323232344415441232323" primary="true" name="Escort"/>
               </categoryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="50.0"/>
+                <cost name="pts" typeId="points" value="50"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="de24-9634-caa0-632a" name="Iconoclast Class Destroyer" hidden="true" collective="false" import="true" type="unit">
@@ -1655,41 +1665,41 @@ Bombers: 20cm</characteristic>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac37-6716-31e9-3e72" type="max"/>
+                <constraint field="selections" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac37-6716-31e9-3e72" type="max"/>
               </constraints>
               <profiles>
                 <profile id="a949-b446-e388-e23e" name="Iconoclast Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
                   <characteristics>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Escort</characteristic>
-                    <characteristic name="Hits" typeId="4869747323232344415441232323">1</characteristic>
-                    <characteristic name="Speed" typeId="537065656423232344415441232323">30cm</characteristic>
+                    <characteristic name="Type" typeId="5.479706523232345e+27">Escort</characteristic>
+                    <characteristic name="Hits" typeId="4.869747323232344e+27">1</characteristic>
+                    <characteristic name="Speed" typeId="5.370656564232324e+29">30cm</characteristic>
                     <characteristic name="Turns" typeId="5475726e7323232344415441232323">90°</characteristic>
                     <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
                     <characteristic name="Armour" typeId="41726d6f757223232344415441232323">4+</characteristic>
-                    <characteristic name="Turrets" typeId="5475727265747323232344415441232323">1</characteristic>
+                    <characteristic name="Turrets" typeId="5.475727265747323e+33">1</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="9139-89d4-8028-69c0" name="Iconoclast Weapons Profile" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="b42d-05bc-1bb6-dc67" name="Escorts" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
+                <categoryLink id="b42d-05bc-1bb6-dc67" name="Escort" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
               </categoryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="30.0"/>
+                <cost name="pts" typeId="points" value="30"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4a0d-cee1-7d2e-1f49" name="Idolator Class Raider" hidden="true" collective="false" import="true" type="unit">
@@ -1699,48 +1709,48 @@ Bombers: 20cm</characteristic>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32cf-4e74-6fee-4005" type="max"/>
+                <constraint field="selections" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32cf-4e74-6fee-4005" type="max"/>
               </constraints>
               <profiles>
                 <profile id="cf98-bb79-a9b8-7d33" name="Idolator Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
                   <characteristics>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Escort</characteristic>
-                    <characteristic name="Hits" typeId="4869747323232344415441232323">1</characteristic>
-                    <characteristic name="Speed" typeId="537065656423232344415441232323">30cm</characteristic>
+                    <characteristic name="Type" typeId="5.479706523232345e+27">Escort</characteristic>
+                    <characteristic name="Hits" typeId="4.869747323232344e+27">1</characteristic>
+                    <characteristic name="Speed" typeId="5.370656564232324e+29">30cm</characteristic>
                     <characteristic name="Turns" typeId="5475726e7323232344415441232323">90°</characteristic>
                     <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
                     <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-                    <characteristic name="Turrets" typeId="5475727265747323232344415441232323">2</characteristic>
+                    <characteristic name="Turrets" typeId="5.475727265747323e+33">2</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="6452-632b-3996-ceef" name="Idolator Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">left/Front/Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">left/Front/Right</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="f184-0f34-7e92-bb80" name="Idolator Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="67eb-a57e-22b4-dbf8" name="Escorts" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
+                <categoryLink id="67eb-a57e-22b4-dbf8" name="Escort" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
               </categoryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="45.0"/>
+                <cost name="pts" typeId="points" value="45"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d279-5710-773c-c02e" name="System Ship" hidden="true" collective="false" import="true" type="unit">
@@ -1749,52 +1759,52 @@ Bombers: 20cm</characteristic>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ffa4-b254-7479-0319" type="max"/>
+                <constraint field="selections" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ffa4-b254-7479-0319" type="max"/>
               </constraints>
               <profiles>
                 <profile id="ca9e-b0ff-d94c-eb53" name="System Ship Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
                   <characteristics>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Defence</characteristic>
-                    <characteristic name="Hits" typeId="4869747323232344415441232323">1</characteristic>
-                    <characteristic name="Speed" typeId="537065656423232344415441232323">15cm</characteristic>
+                    <characteristic name="Type" typeId="5.479706523232345e+27">Defence</characteristic>
+                    <characteristic name="Hits" typeId="4.869747323232344e+27">1</characteristic>
+                    <characteristic name="Speed" typeId="5.370656564232324e+29">15cm</characteristic>
                     <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
                     <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
                     <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-                    <characteristic name="Turrets" typeId="5475727265747323232344415441232323">1</characteristic>
+                    <characteristic name="Turrets" typeId="5.475727265747323e+33">1</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="bb3e-9ce6-6a46-fc87" name="System Ship Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="baa6-155b-33ce-5d78" name="Escorts" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
+                <categoryLink id="baa6-155b-33ce-5d78" name="Escort" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
               </categoryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
+                <cost name="pts" typeId="points" value="20"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eef5-7a13-798f-3214" name="Havoc Class Frigate" publicationId="5766-7751-d146-0800" page="43" hidden="true" collective="false" import="true" type="unit">
               <modifiers>
-                <modifier type="increment" field="points" value="5.0">
+                <modifier type="increment" field="points" value="5">
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7346-ab43-9438-149f" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82c2-f360-d49f-cb84" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5b8b-7613-df6a-8977" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6577-54b5-e6c6-11c5" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7346-ab43-9438-149f" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82c2-f360-d49f-cb84" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5b8b-7613-df6a-8977" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6577-54b5-e6c6-11c5" type="instanceOf"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -1803,43 +1813,43 @@ Bombers: 20cm</characteristic>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="03e7-6be8-18fa-d7e3" type="max"/>
+                <constraint field="selections" scope="parent" value="6" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="03e7-6be8-18fa-d7e3" type="max"/>
               </constraints>
               <profiles>
                 <profile id="db96-04fe-0a49-733e" name="Havoc Class Frigate" publicationId="5766-7751-d146-0800" page="43" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
                   <characteristics>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Escort</characteristic>
-                    <characteristic name="Hits" typeId="4869747323232344415441232323">1</characteristic>
-                    <characteristic name="Speed" typeId="537065656423232344415441232323">25</characteristic>
+                    <characteristic name="Type" typeId="5.479706523232345e+27">Escort</characteristic>
+                    <characteristic name="Hits" typeId="4.869747323232344e+27">1</characteristic>
+                    <characteristic name="Speed" typeId="5.370656564232324e+29">25</characteristic>
                     <characteristic name="Turns" typeId="5475726e7323232344415441232323">90</characteristic>
                     <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
                     <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-                    <characteristic name="Turrets" typeId="5475727265747323232344415441232323">2</characteristic>
+                    <characteristic name="Turrets" typeId="5.475727265747323e+33">2</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="0633-d0c6-68bf-fa54" name="Havoc Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/right/front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/right/front</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="7d16-a42b-7854-32db" hidden="false" targetId="4573636f72747323232344415441232323" primary="true"/>
+                <categoryLink id="7d16-a42b-7854-32db" hidden="false" targetId="4573636f72747323232344415441232323" primary="true" name="Escort"/>
               </categoryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="35.0"/>
+                <cost name="pts" typeId="points" value="35"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6e43-5c77-250d-db65" name="Recommissioned Vessel" hidden="true" collective="false" import="true" type="model">
@@ -1848,8 +1858,8 @@ Bombers: 20cm</characteristic>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -1858,27 +1868,27 @@ Bombers: 20cm</characteristic>
               <profiles>
                 <profile id="4f5f-dd2b-7523-07b9" name="Recommissioned Vessel Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
                   <characteristics>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Escort</characteristic>
-                    <characteristic name="Hits" typeId="4869747323232344415441232323">1</characteristic>
-                    <characteristic name="Speed" typeId="537065656423232344415441232323">30cm</characteristic>
+                    <characteristic name="Type" typeId="5.479706523232345e+27">Escort</characteristic>
+                    <characteristic name="Hits" typeId="4.869747323232344e+27">1</characteristic>
+                    <characteristic name="Speed" typeId="5.370656564232324e+29">30cm</characteristic>
                     <characteristic name="Turns" typeId="5475726e7323232344415441232323">90°</characteristic>
                     <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
                     <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-                    <characteristic name="Turrets" typeId="5475727265747323232344415441232323">1</characteristic>
+                    <characteristic name="Turrets" typeId="5.475727265747323e+33">1</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="3544-9fad-d1de-a410" name="Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="3cd0-a593-0f4b-1de9" name="Prow Torpedoes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -1886,13 +1896,13 @@ Bombers: 20cm</characteristic>
                 <infoLink id="efa0-31af-81f0-0124" name="Torpedoes" hidden="false" targetId="8103-25d2-5412-2542" type="rule"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink id="f87a-f548-4eb6-07e1" name="New CategoryLink" hidden="false" targetId="4573636f72747323232344415441232323" primary="true"/>
+                <categoryLink id="f87a-f548-4eb6-07e1" name="Escort" hidden="false" targetId="4573636f72747323232344415441232323" primary="true"/>
               </categoryLinks>
               <entryLinks>
                 <entryLink id="ff26-c7c5-e235-2a72" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="30.0"/>
+                <cost name="pts" typeId="points" value="30"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1901,12 +1911,12 @@ Bombers: 20cm</characteristic>
               <modifiers>
                 <modifier type="set" field="name" value="Rapid Strike Firestorm Frigate">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="points" value="45.0">
+                <modifier type="set" field="points" value="45">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1918,12 +1928,12 @@ Bombers: 20cm</characteristic>
               <modifiers>
                 <modifier type="set" field="name" value="Rapid Strike SwordFrigate">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
                   </conditions>
                 </modifier>
-                <modifier type="set" field="points" value="40.0">
+                <modifier type="set" field="points" value="40">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1932,7 +1942,7 @@ Bombers: 20cm</characteristic>
                   <modifiers>
                     <modifier type="set" field="hidden" value="false">
                       <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -1942,14 +1952,14 @@ Bombers: 20cm</characteristic>
             </entryLink>
             <entryLink id="e783-5abe-e5a9-88ec" name="Cobra Destroyer" hidden="false" collective="false" import="true" targetId="fd70-2a36-263f-1ab7" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="points" value="35.0">
+                <modifier type="set" field="points" value="35">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
                   </conditions>
                 </modifier>
                 <modifier type="set" field="name" value="Rapid Strike Cobra Destroyer">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1958,7 +1968,7 @@ Bombers: 20cm</characteristic>
                   <modifiers>
                     <modifier type="set" field="hidden" value="false">
                       <conditions>
-                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -1967,7 +1977,7 @@ Bombers: 20cm</characteristic>
               <entryLinks>
                 <entryLink id="7b63-bd55-7c2c-c044" name="Widowmaker Cobra" hidden="false" collective="false" import="true" targetId="dc88-f7ed-8352-4f11" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cd1-e8dd-1d21-e91b" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cd1-e8dd-1d21-e91b" type="max"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
@@ -1980,8 +1990,8 @@ Bombers: 20cm</characteristic>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -1994,8 +2004,8 @@ Bombers: 20cm</characteristic>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -2008,8 +2018,8 @@ Bombers: 20cm</characteristic>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -2022,8 +2032,8 @@ Bombers: 20cm</characteristic>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -2036,8 +2046,8 @@ Bombers: 20cm</characteristic>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -2050,8 +2060,8 @@ Bombers: 20cm</characteristic>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -2064,8 +2074,8 @@ Bombers: 20cm</characteristic>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -2079,25 +2089,25 @@ Bombers: 20cm</characteristic>
         <entryLink id="dd7f-69ef-936c-24d2" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3fca-d065-ff67-cd0d" name="Eternal Crusader" hidden="true" collective="false" import="true" type="model">
       <modifiers>
-        <modifier type="set" field="963a-b0f4-a171-7a58" value="0.0">
+        <modifier type="set" field="963a-b0f4-a171-7a58" value="0">
           <conditions>
-            <condition field="points" scope="force" value="2000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="lessThan"/>
+            <condition field="points" scope="force" value="2000" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="lessThan"/>
           </conditions>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1042-e458-4e02-a537" type="atLeast"/>
+                <condition field="selections" scope="force" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1042-e458-4e02-a537" type="atLeast"/>
               </conditions>
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4361706974616c20536869707323232344415441232323" type="atLeast"/>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1042-e458-4e02-a537" type="atLeast"/>
+                    <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4361706974616c20536869707323232344415441232323" type="atLeast"/>
+                    <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1042-e458-4e02-a537" type="atLeast"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -2108,77 +2118,77 @@ Bombers: 20cm</characteristic>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="963a-b0f4-a171-7a58" type="max"/>
+        <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="963a-b0f4-a171-7a58" type="max"/>
       </constraints>
       <profiles>
         <profile id="9349-df31-d252-d350" name="Eternal Crusader" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Battleship</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">14</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Battleship</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">14</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">4</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">6+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">4</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">4</characteristic>
           </characteristics>
         </profile>
         <profile id="6406-6e33-f37f-f9b1" name="Eternal Crusader Prow Launch Bay" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">20cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2 Thunderhawks</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
         <profile id="ec92-8ce2-cc57-14e4" name="Eternal Crusader Prow Torpedoes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
           </characteristics>
         </profile>
         <profile id="6451-fc02-680b-8fa1" name="Eternal Crusader Dorsal Bombardment Cannons" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">8</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
         <profile id="f427-9132-6f32-93e8" name="Eternal Crusader Port Weapons Batteries" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">12</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="b3c2-3843-72b3-8fea" name="Eternal Crusader Starboard Weapons Batteries" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">12</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="729c-05bb-b547-b07d" name="Eternal Crusader Port Launch Bay" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">20cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2 Thunderhawks</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
         <profile id="3a45-5efe-f475-0c62" name="Eternal Crusader Starboard Launch Bay" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">20cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2 Thunderhawks</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
-        <profile id="0443-983a-aef7-7adc" name="High Marshal" page="" hidden="false" typeId="436f6d6d616e64657223232344415441232323" typeName="Commander">
+        <profile id="0443-983a-aef7-7adc" name="High Marshal" hidden="false" typeId="436f6d6d616e64657223232344415441232323" typeName="Commander">
           <characteristics>
             <characteristic name="Leadership" typeId="4c65616465727368697023232344415441232323">10</characteristic>
             <characteristic name="Re-rolls" typeId="52652d726f6c6c7323232344415441232323">1 per turn</characteristic>
@@ -2203,14 +2213,14 @@ Scores 3 points in a planetary assault rather than 2.</description>
         </rule>
       </rules>
       <categoryLinks>
-        <categoryLink id="b493-1a5a-eebb-8b7d" name="New CategoryLink" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true"/>
+        <categoryLink id="b493-1a5a-eebb-8b7d" name="Battleship" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="9e1c-423b-2673-36d8" name="Thunderhawks" hidden="false" collective="false" import="true" targetId="f785-b032-dacc-80a4" type="selectionEntryGroup"/>
         <entryLink id="6629-5b68-5e17-5bc1" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="745.0"/>
+        <cost name="pts" typeId="points" value="745"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6cf7-bc84-05fa-1b2d" name="Forgeship" hidden="true" collective="false" import="true" type="model">
@@ -2219,39 +2229,39 @@ Scores 3 points in a planetary assault rather than 2.</description>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1370-6908-1b0b-68c1" type="max"/>
+        <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1370-6908-1b0b-68c1" type="max"/>
       </constraints>
       <profiles>
         <profile id="b857-de12-c24e-c527" name="Forgeship" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">10</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">10</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">3</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">3</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">3</characteristic>
           </characteristics>
         </profile>
         <profile id="f80c-1bf1-fa4c-7cf3" name="Forgeship Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">10</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="b269-6130-8e31-d88b" name="Forgeship Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">10</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -2265,51 +2275,51 @@ Scores 3 points in a planetary assault rather than 2.</description>
         </rule>
       </rules>
       <categoryLinks>
-        <categoryLink id="cb2c-7f75-c48d-99b4" name="Grand Cruisers" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="true"/>
+        <categoryLink id="cb2c-7f75-c48d-99b4" name="Grand Cruiser" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="50fc-5927-9379-00f7" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="300.0"/>
+        <cost name="pts" typeId="points" value="300"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="05a2-e98b-b0dc-780f" name="Marshal" page="0" hidden="true" collective="false" import="true" type="upgrade">
       <modifiers>
-        <modifier type="set" field="1fb6-6113-25bb-3661" value="0.0">
+        <modifier type="set" field="1fb6-6113-25bb-3661" value="0">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3fca-d065-ff67-cd0d" type="atLeast"/>
+            <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3fca-d065-ff67-cd0d" type="atLeast"/>
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="1fb6-6113-25bb-3661" type="max"/>
+        <constraint field="selections" scope="roster" value="1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="1fb6-6113-25bb-3661" type="max"/>
       </constraints>
       <profiles>
         <profile id="a106-6509-b21a-1f03" name="Marshal" hidden="false" typeId="436f6d6d616e64657223232344415441232323" typeName="Commander">
           <modifiers>
             <modifier type="increment" field="52652d726f6c6c7323232344415441232323" value="1">
               <conditions>
-                <condition field="selections" scope="05a2-e98b-b0dc-780f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ce83-a7df-2dc6-420a" type="equalTo"/>
+                <condition field="selections" scope="05a2-e98b-b0dc-780f" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ce83-a7df-2dc6-420a" type="equalTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="52652d726f6c6c7323232344415441232323" value="2">
               <conditions>
-                <condition field="selections" scope="05a2-e98b-b0dc-780f" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ce83-a7df-2dc6-420a" type="equalTo"/>
+                <condition field="selections" scope="05a2-e98b-b0dc-780f" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ce83-a7df-2dc6-420a" type="equalTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="52652d726f6c6c7323232344415441232323" value="3">
               <conditions>
-                <condition field="selections" scope="05a2-e98b-b0dc-780f" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ce83-a7df-2dc6-420a" type="equalTo"/>
+                <condition field="selections" scope="05a2-e98b-b0dc-780f" value="3" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ce83-a7df-2dc6-420a" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -2321,38 +2331,38 @@ Scores 3 points in a planetary assault rather than 2.</description>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="1b9e-30f9-08f6-335b" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="true"/>
+        <categoryLink id="1b9e-30f9-08f6-335b" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="true" name="Fleet Commander"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ce83-a7df-2dc6-420a" name="Extra Re-Rolls (Max 3)" page="0" hidden="false" collective="false" import="true" type="unit">
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="97de-5ca3-85d0-ac0c" type="max"/>
+            <constraint field="selections" scope="parent" value="3" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="97de-5ca3-85d0-ac0c" type="max"/>
           </constraints>
           <costs>
-            <cost name="pts" typeId="points" value="25.0"/>
+            <cost name="pts" typeId="points" value="25"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="5f6d-d5f4-a32d-1d9e" name="Sword Bretheren" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac95-133a-9fad-4235" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac95-133a-9fad-4235" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="25c4-2178-135f-fd34" name="Terminator Teleport Assault" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f36-a763-8dd6-ab27" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f36-a763-8dd6-ab27" type="max"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
+                <cost name="pts" typeId="points" value="10"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="pts" typeId="points" value="50.0"/>
+            <cost name="pts" typeId="points" value="50"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
-        <cost name="pts" typeId="points" value="50.0"/>
+        <cost name="pts" typeId="points" value="50"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d776-183f-430c-639a" name="Venerable Battlebarge" page="0" hidden="true" collective="false" import="true" type="model">
@@ -2361,74 +2371,74 @@ Scores 3 points in a planetary assault rather than 2.</description>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="197f-d5ca-a543-ae00" type="max"/>
+        <constraint field="selections" scope="force" value="1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="197f-d5ca-a543-ae00" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="68cd-2ae2-6fc1-fbd6" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true"/>
+        <categoryLink id="68cd-2ae2-6fc1-fbd6" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true" name="Battleship"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="5c21-c922-92a1-f3d7" name="Ship Model" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0613-93bb-8210-a9b8" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="74aa-c721-c0b1-8f56" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0613-93bb-8210-a9b8" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="74aa-c721-c0b1-8f56" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="e8dd-0916-7cbc-95b2" name="Venerable Battlebarge Seditio Opprimere" page="0" hidden="false" collective="false" import="true" type="unit">
               <constraints>
-                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="5287-2b90-612d-14e4" type="max"/>
+                <constraint field="selections" scope="roster" value="1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="5287-2b90-612d-14e4" type="max"/>
               </constraints>
               <profiles>
                 <profile id="19ff-590c-3df6-5e31" name="Seditio Opprimere Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
                   <characteristics>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Battleship</characteristic>
-                    <characteristic name="Hits" typeId="4869747323232344415441232323">12</characteristic>
-                    <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+                    <characteristic name="Type" typeId="5.479706523232345e+27">Battleship</characteristic>
+                    <characteristic name="Hits" typeId="4.869747323232344e+27">12</characteristic>
+                    <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
                     <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
                     <characteristic name="Shields" typeId="536869656c647323232344415441232323">4</characteristic>
                     <characteristic name="Armour" typeId="41726d6f757223232344415441232323">6+</characteristic>
-                    <characteristic name="Turrets" typeId="5475727265747323232344415441232323">4</characteristic>
+                    <characteristic name="Turrets" typeId="5.475727265747323e+33">4</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="8959-e789-40b7-e72c" name="Seditio Opprimere Port Bombardment Cannon" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">8</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="81fc-0008-090f-fb26" name="Seditio Opprimere Starboard Bombardment Cannon" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">8</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="d9c0-cb8a-177b-feb4" name="Seditio Opprimere Dorsal Bombardment Cannon" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">8</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="9d4c-895c-f083-bb81" name="Seditio Opprimere Prow Launch Bay" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Thunderhawks: 20cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2 Squadrons</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="76ec-1521-6817-b2e7" name="Seditio Opprimere Prow Torpedos" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -2436,44 +2446,44 @@ Scores 3 points in a planetary assault rather than 2.</description>
                 <infoLink id="b888-e41c-f56e-51f1" name="May not use the &quot;come to new heading&quot; special order" hidden="false" targetId="b1a1-aead-ea5a-d8d3" type="rule"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink id="2606-f9f3-f0d9-240e" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true"/>
+                <categoryLink id="2606-f9f3-f0d9-240e" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true" name="Battleship"/>
               </categoryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="415.0"/>
+                <cost name="pts" typeId="points" value="415"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2343-69f3-f40a-66b2" name="Loyalist Venerable Battlebarge" publicationId="44fa-5ffb-b627-7106" page="111" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="4a65-1bf7-939e-26a1" name="Vengeful Spirit Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
                   <characteristics>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Battleship</characteristic>
-                    <characteristic name="Hits" typeId="4869747323232344415441232323">12</characteristic>
-                    <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+                    <characteristic name="Type" typeId="5.479706523232345e+27">Battleship</characteristic>
+                    <characteristic name="Hits" typeId="4.869747323232344e+27">12</characteristic>
+                    <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
                     <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
                     <characteristic name="Shields" typeId="536869656c647323232344415441232323">4</characteristic>
                     <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-                    <characteristic name="Turrets" typeId="5475727265747323232344415441232323">4</characteristic>
+                    <characteristic name="Turrets" typeId="5.475727265747323e+33">4</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="0c04-e890-616f-633a" name="Vengeful Spirit Port Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Swiftdeaths: 30cm Doomfires: 20cm Dreadclaws: 30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="cf74-c8ee-8386-5f33" name="Vengeful Spirit Starboard Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Swiftdeaths: 30cm Doomfires: 20cm Dreadclaws: 30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="5c93-42aa-175f-3754" name="Vengeful Spirit Prow Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Swiftdeaths: 30cm Doomfires: 20cm Dreadclaws: 30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -2481,105 +2491,105 @@ Scores 3 points in a planetary assault rather than 2.</description>
                 <infoLink id="b34f-7ac2-dc26-9326" name="May not use the &quot;come to new heading&quot; special order" hidden="false" targetId="b1a1-aead-ea5a-d8d3" type="rule"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink id="dd34-6d7b-8ccc-2d05" name="New CategoryLink" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true"/>
+                <categoryLink id="dd34-6d7b-8ccc-2d05" name="Battleship" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true"/>
               </categoryLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="271e-dccb-44fb-4933" name="Chaos Battlebarge Weapons Battery Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="1961-efed-cd96-84e0">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cda2-c489-1b12-a1de" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c993-df20-4611-5f94" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cda2-c489-1b12-a1de" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c993-df20-4611-5f94" type="min"/>
                   </constraints>
                   <selectionEntries>
                     <selectionEntry id="1c46-0ce8-689f-fc11" name="Exchange Broadside Weapon Batteries for Range 45cm, Firepower 8" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b1e-4efc-e9cd-1472" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b1e-4efc-e9cd-1472" type="max"/>
                       </constraints>
                       <profiles>
                         <profile id="2233-7034-c5c9-03f0" name="Battlebarge Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                           <characteristics>
                             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
                             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">8</characteristic>
-                            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+                            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
                           </characteristics>
                         </profile>
                         <profile id="a414-3bed-9da3-250e" name="Battlebarge Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                           <characteristics>
                             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
                             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">8</characteristic>
-                            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+                            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
                           </characteristics>
                         </profile>
                       </profiles>
                       <costs>
-                        <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name="pts" typeId="points" value="0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1fba-278d-2ac5-1fe7" name="Exchange Broadside Weapon Batteries for Range-30cm, Firepower-10." hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65eb-99e6-75e3-2039" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65eb-99e6-75e3-2039" type="max"/>
                       </constraints>
                       <profiles>
                         <profile id="1b02-686b-d3b0-1d58" name="Battlebarge Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                           <characteristics>
                             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">10</characteristic>
-                            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+                            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
                           </characteristics>
                         </profile>
                         <profile id="b53e-c06c-9028-3d77" name="Battlebarge Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                           <characteristics>
                             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">10</characteristic>
-                            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+                            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
                           </characteristics>
                         </profile>
                       </profiles>
                       <costs>
-                        <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name="pts" typeId="points" value="0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1961-efed-cd96-84e0" name="Vengeful Spirit" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a79-70e5-b393-6d7d" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a79-70e5-b393-6d7d" type="max"/>
                       </constraints>
                       <profiles>
                         <profile id="6e1b-309e-f556-32dc" name="Vengeful Spirit Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                           <characteristics>
                             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
                             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+                            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
                           </characteristics>
                         </profile>
                         <profile id="769a-663e-a33e-d7ea" name="Vengeful Spirit Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                           <characteristics>
                             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
                             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+                            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
                           </characteristics>
                         </profile>
                       </profiles>
                       <costs>
-                        <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name="pts" typeId="points" value="0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="9718-2963-78ab-3576" name="Chaos Battlebarge Prow Weapons Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="9269-490d-f76b-01f3">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1de0-4560-b028-64b6" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f907-f2ad-0882-0f02" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1de0-4560-b028-64b6" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f907-f2ad-0882-0f02" type="min"/>
                   </constraints>
                   <selectionEntries>
                     <selectionEntry id="5f61-2e31-072e-2bd7" name="Torpedo Tubes" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="49e4-9458-fa43-671e" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="49e4-9458-fa43-671e" type="max"/>
                       </constraints>
                       <profiles>
                         <profile id="1ca1-bd95-2679-8553" name="Chaos Battlebarge Prow Torpedo Tubes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                           <characteristics>
                             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">8</characteristic>
-                            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                           </characteristics>
                         </profile>
                       </profiles>
@@ -2587,12 +2597,12 @@ Scores 3 points in a planetary assault rather than 2.</description>
                         <infoLink id="e9a6-2dae-3f98-f362" name="Torpedoes" hidden="false" targetId="8103-25d2-5412-2542" type="rule"/>
                       </infoLinks>
                       <costs>
-                        <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name="pts" typeId="points" value="10"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="9269-490d-f76b-01f3" name="Vengeful Spirit" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50a0-810a-cced-51d6" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50a0-810a-cced-51d6" type="max"/>
                       </constraints>
                       <profiles>
                         <profile id="b743-3947-e40c-3594" name="Vengeful Spirit Prow Lances" hidden="false" typeId="436f6d6d616e64657223232344415441232323" typeName="Commander">
@@ -2604,49 +2614,49 @@ Scores 3 points in a planetary assault rather than 2.</description>
                         </profile>
                       </profiles>
                       <costs>
-                        <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name="pts" typeId="points" value="0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="64ee-6981-a913-e6b0" name="Dorsal Weapons Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="9f82-9985-f9fc-feb1">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7546-e3ed-a258-7e5a" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4ad-14ee-9a3d-94bb" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7546-e3ed-a258-7e5a" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4ad-14ee-9a3d-94bb" type="min"/>
                   </constraints>
                   <selectionEntries>
                     <selectionEntry id="ce8f-208a-ad42-01a5" name="Range 45cm, Strength 4 Lances" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4274-a9c6-5cca-11bf" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4274-a9c6-5cca-11bf" type="max"/>
                       </constraints>
                       <profiles>
                         <profile id="ae25-9772-cb4d-8aa2" name="Dorsal Lances" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                           <characteristics>
                             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
                             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-                            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+                            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
                           </characteristics>
                         </profile>
                       </profiles>
                       <costs>
-                        <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name="pts" typeId="points" value="10"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="9f82-9985-f9fc-feb1" name="Vengeful Spirit" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d653-e807-63d1-de8a" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d653-e807-63d1-de8a" type="max"/>
                       </constraints>
                       <profiles>
                         <profile id="a8ed-3332-9bd8-568b" name="Vengeful Spirit Dorsal Lances" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                           <characteristics>
                             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
                             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3</characteristic>
-                            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+                            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
                           </characteristics>
                         </profile>
                       </profiles>
                       <costs>
-                        <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name="pts" typeId="points" value="0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2656,7 +2666,7 @@ Scores 3 points in a planetary assault rather than 2.</description>
                 <entryLink id="78e8-fd43-e38a-4b00" name="Thunderhawks" hidden="false" collective="false" import="true" targetId="0fa9-847e-cb53-9990" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="445.0"/>
+                <cost name="pts" typeId="points" value="445"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2666,10 +2676,10 @@ Scores 3 points in a planetary assault rather than 2.</description>
                 <modifier type="set" field="hidden" value="false"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ce4-3873-736f-d50a" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ce4-3873-736f-d50a" type="max"/>
               </constraints>
               <categoryLinks>
-                <categoryLink id="bfb6-e145-fe27-a9d0" name="Battleships" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false"/>
+                <categoryLink id="bfb6-e145-fe27-a9d0" name="Battleship" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false"/>
               </categoryLinks>
             </entryLink>
             <entryLink id="2f7c-627a-c0a9-2f0b" name="Desolator Class Battleship" hidden="false" collective="false" import="true" targetId="7ecf-1d59-fc1a-10ff" type="selectionEntry">
@@ -2677,7 +2687,7 @@ Scores 3 points in a planetary assault rather than 2.</description>
                 <modifier type="set" field="hidden" value="false"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc00-35cd-66ba-fd46" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc00-35cd-66ba-fd46" type="max"/>
               </constraints>
             </entryLink>
             <entryLink id="971b-b5e0-4b5a-7e53" name="Despoiler Class Battleship" hidden="false" collective="false" import="true" targetId="48f8-b2a8-d4ce-4888" type="selectionEntry">
@@ -2685,7 +2695,7 @@ Scores 3 points in a planetary assault rather than 2.</description>
                 <modifier type="set" field="hidden" value="false"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1395-40a8-56cb-16ef" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1395-40a8-56cb-16ef" type="max"/>
               </constraints>
             </entryLink>
             <entryLink id="483d-c0e9-8589-736b" name="Executor Class Grand Cruiser" hidden="false" collective="false" import="true" targetId="05d4-f556-2999-f12d" type="selectionEntry">
@@ -2693,7 +2703,7 @@ Scores 3 points in a planetary assault rather than 2.</description>
                 <modifier type="set" field="hidden" value="false"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9ff-d899-a1f6-7db1" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9ff-d899-a1f6-7db1" type="max"/>
               </constraints>
             </entryLink>
             <entryLink id="1df9-9a6f-7973-fd83" name="Hades Class Heavy Cruiser" hidden="false" collective="false" import="true" targetId="5ab1-9f2a-0485-39db" type="selectionEntry">
@@ -2701,7 +2711,7 @@ Scores 3 points in a planetary assault rather than 2.</description>
                 <modifier type="set" field="hidden" value="false"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b531-2ebd-9dd6-456a" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b531-2ebd-9dd6-456a" type="max"/>
               </constraints>
             </entryLink>
             <entryLink id="3c61-2124-accb-362d" name="Repulsive Class Grand Cruiser" hidden="false" collective="false" import="true" targetId="236b-8abc-b681-f47b" type="selectionEntry">
@@ -2709,7 +2719,7 @@ Scores 3 points in a planetary assault rather than 2.</description>
                 <modifier type="set" field="hidden" value="false"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9521-4ecc-8bc7-406e" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9521-4ecc-8bc7-406e" type="max"/>
               </constraints>
             </entryLink>
             <entryLink id="adc3-d02b-79ee-91b7" name="Retaliator Class Grand Cruiser" hidden="false" collective="false" import="true" targetId="74b8-8c23-fc12-b300" type="selectionEntry">
@@ -2717,7 +2727,7 @@ Scores 3 points in a planetary assault rather than 2.</description>
                 <modifier type="set" field="hidden" value="false"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52d4-941a-5905-96fe" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52d4-941a-5905-96fe" type="max"/>
               </constraints>
             </entryLink>
             <entryLink id="d232-d966-6846-dd85" name="Styx Class Heavy Cruiser" hidden="false" collective="false" import="true" targetId="da54-1698-df9e-8979" type="selectionEntry">
@@ -2725,7 +2735,7 @@ Scores 3 points in a planetary assault rather than 2.</description>
                 <modifier type="set" field="hidden" value="false"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84c8-1de7-2a67-cc4a" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84c8-1de7-2a67-cc4a" type="max"/>
               </constraints>
             </entryLink>
             <entryLink id="3b08-348a-2c18-a13f" name="Vengeance Class Grand Cruiser" hidden="false" collective="false" import="true" targetId="58eb-48b5-7e42-8bc7" type="selectionEntry">
@@ -2733,10 +2743,10 @@ Scores 3 points in a planetary assault rather than 2.</description>
                 <modifier type="set" field="hidden" value="false"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe3f-8cb5-9eaf-6198" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe3f-8cb5-9eaf-6198" type="max"/>
               </constraints>
               <categoryLinks>
-                <categoryLink id="ab30-0cd4-91aa-3dc3" name="Battlecruisers &amp; Heavy Cruisers" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
+                <categoryLink id="ab30-0cd4-91aa-3dc3" name="Heavy Cruiser" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
               </categoryLinks>
             </entryLink>
             <entryLink id="2a61-7255-98fc-0c9d" name="Apocalypse Class Battleship" hidden="false" collective="false" import="true" targetId="c133-b14e-e57c-cb12" type="selectionEntry"/>
@@ -2762,26 +2772,26 @@ Scores 3 points in a planetary assault rather than 2.</description>
         <entryLink id="8c12-eabd-a4d4-d506" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="35.0"/>
+        <cost name="pts" typeId="points" value="35"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="95ed-7cb1-547e-b6d4" name="Dictator Class Cruiser" publicationId="11f0-17d1-e4d2-1018" page="112" hidden="true" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="increment" field="points" value="35">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed8-4a6a-2f2b-833d" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed8-4a6a-2f2b-833d" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -2790,34 +2800,34 @@ Scores 3 points in a planetary assault rather than 2.</description>
       <profiles>
         <profile id="f466-af5b-81b7-58b6" name="Dictator Profile" publicationId="11f0-17d1-e4d2-1018" page="112" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">8</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">8</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">2</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">6+Front/5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">3</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">3</characteristic>
           </characteristics>
         </profile>
         <profile id="a6a7-f61d-9b6c-3a50" name="Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="514b-842c-1e31-64f6" name="Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="541d-2456-e62b-989a" name="Port Launch bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <modifiers>
             <modifier type="append" field="52616e67652f537065656423232344415441232323" value="Torpedo Bomber: 20cm (STR 2)">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beba-9f13-d04b-6ad6" type="instanceOf"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beba-9f13-d04b-6ad6" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -2825,14 +2835,14 @@ Scores 3 points in a planetary assault rather than 2.</description>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Furies: 30cm
 Starhawks: 20cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2 Squadrons</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
         <profile id="f7e5-e20d-ea6e-0fb2" name="Starboard Launch bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <modifiers>
             <modifier type="append" field="52616e67652f537065656423232344415441232323" value="Torpedo Bomber: 20cm (STR 2)">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beba-9f13-d04b-6ad6" type="instanceOf"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beba-9f13-d04b-6ad6" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -2840,31 +2850,31 @@ Starhawks: 20cm</characteristic>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Furies: 30cm
 Starhawks: 20cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2 Squadrons</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="dc82-5c5e-0d23-4d0e" name="New CategoryLink" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
+        <categoryLink id="dc82-5c5e-0d23-4d0e" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
         <categoryLink id="719a-a3bf-1603-20e4" name="CV" hidden="false" targetId="e0c6-bde4-7055-1e6e" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="1df8-92a0-c523-5519" name="Prow Weapons Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="fe2d-3a7e-709d-c9e3">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="320d-94be-599d-1a0c" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2a6c-efdf-7ee8-b843" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="320d-94be-599d-1a0c" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2a6c-efdf-7ee8-b843" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="fe2d-3a7e-709d-c9e3" name="Prow Torpedoes" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d2e9-0d97-b956-7a56" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d2e9-0d97-b956-7a56" type="max"/>
               </constraints>
               <profiles>
                 <profile id="e28d-cd7b-685f-48dd" name="Prow Torpedoes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -2872,7 +2882,7 @@ Starhawks: 20cm</characteristic>
                 <infoLink id="601d-a8ae-97fb-ede7" name="Torpedoes" hidden="false" targetId="8103-25d2-5412-2542" type="rule"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2881,7 +2891,7 @@ Starhawks: 20cm</characteristic>
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -2896,7 +2906,7 @@ Starhawks: 20cm</characteristic>
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -2906,7 +2916,7 @@ Starhawks: 20cm</characteristic>
             <modifier type="increment" field="points" value="30"/>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -2914,7 +2924,7 @@ Starhawks: 20cm</characteristic>
         <entryLink id="cc13-360d-3744-1222" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="220.0"/>
+        <cost name="pts" typeId="points" value="220"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c6c4-e97d-9bed-fdfa" name="Dominator Class Cruiser" publicationId="11f0-17d1-e4d2-1018" page="111" hidden="true" collective="false" import="true" type="model">
@@ -2923,10 +2933,10 @@ Starhawks: 20cm</characteristic>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed8-4a6a-2f2b-833d" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed8-4a6a-2f2b-833d" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -2935,20 +2945,20 @@ Starhawks: 20cm</characteristic>
       <profiles>
         <profile id="dbb6-f375-51cb-00f6" name="Dominator Profile" publicationId="11f0-17d1-e4d2-1018" page="111" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <modifiers>
-            <modifier type="increment" field="5475727265747323232344415441232323" value="1">
+            <modifier type="increment" field="5.475727265747323e+33" value="1">
               <conditions>
-                <condition field="selections" scope="c6c4-e97d-9bed-fdfa" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8025-e5ea-9b7b-7f59" type="atLeast"/>
+                <condition field="selections" scope="c6c4-e97d-9bed-fdfa" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8025-e5ea-9b7b-7f59" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">8</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">8</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">2</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">6+Front/5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">2</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">2</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -2956,63 +2966,63 @@ Starhawks: 20cm</characteristic>
         <infoLink id="2dce-6cf2-16d4-0fec" name="Prow Nova Cannon" hidden="false" targetId="af91-33ff-94d6-44f4" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="b7d5-6ea5-7e88-a012" name="New CategoryLink" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
+        <categoryLink id="b7d5-6ea5-7e88-a012" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
         <categoryLink id="10dc-351e-302e-149b" name="CV" hidden="false" targetId="e0c6-bde4-7055-1e6e" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="2b86-8a46-08fb-1996" name="Varient" hidden="false" collective="false" import="true" defaultSelectionEntryId="fa07-903e-532d-f514">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e229-a8f4-9199-3019" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d96-174a-7515-c1a0" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e229-a8f4-9199-3019" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d96-174a-7515-c1a0" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="5387-2ad9-998f-ec4b" name="Hammer of Justice (45cm WB)" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f48-0e77-ff57-a27f" type="max"/>
-                <constraint field="selections" scope="primary-catalogue" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef48-225d-6b20-6442" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f48-0e77-ff57-a27f" type="max"/>
+                <constraint field="selections" scope="primary-catalogue" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef48-225d-6b20-6442" type="max"/>
               </constraints>
               <profiles>
                 <profile id="0496-30ea-ebac-5268" name="Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="fc8d-52b2-16e4-1391" name="Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="-5.0"/>
+                <cost name="pts" typeId="points" value="-5"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fa07-903e-532d-f514" name="Standard" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97d4-039f-1ec2-b093" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97d4-039f-1ec2-b093" type="max"/>
               </constraints>
               <profiles>
                 <profile id="775e-e5a8-4699-55d0" name="Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">12</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="9ac7-43e1-c183-118f" name="Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">12</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3024,7 +3034,7 @@ Starhawks: 20cm</characteristic>
         <entryLink id="1dd7-56a2-2fab-b037" name="Bakka Turret" hidden="false" collective="false" import="true" targetId="8025-e5ea-9b7b-7f59" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="190.0"/>
+        <cost name="pts" typeId="points" value="190"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="019a-ed13-23b9-b24f" name="Inquisitor Lord" page="0" hidden="true" collective="false" import="true" type="upgrade">
@@ -3033,21 +3043,21 @@ Starhawks: 20cm</characteristic>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="e9ee-1277-82f1-25a5" type="max"/>
+        <constraint field="selections" scope="roster" value="1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="e9ee-1277-82f1-25a5" type="max"/>
       </constraints>
       <profiles>
         <profile id="d477-5493-ef92-09b3" name="Inquisitor Lord" publicationId="44fa-5ffb-b627-7106" page="51" hidden="false" typeId="436f6d6d616e64657223232344415441232323" typeName="Commander">
           <modifiers>
             <modifier type="increment" field="52652d726f6c6c7323232344415441232323" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="85b5-1773-1b16-e68e" type="instanceOf"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="85b5-1773-1b16-e68e" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -3064,62 +3074,62 @@ Starhawks: 20cm</characteristic>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="b143-bf16-1731-8320" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="true"/>
+        <categoryLink id="b143-bf16-1731-8320" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="true" name="Fleet Commander"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="85b5-1773-1b16-e68e" name="Additional Re-Roll" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0fcc-bf1e-c491-20ff" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0fcc-bf1e-c491-20ff" type="max"/>
           </constraints>
           <costs>
-            <cost name="pts" typeId="points" value="25.0"/>
+            <cost name="pts" typeId="points" value="25"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="743d-5019-3c42-e1aa" name="Ordo" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f78b-340e-d6fb-e9fa" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f78b-340e-d6fb-e9fa" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="b1d9-9422-9c2b-cb31" name="Ordo Xenos" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <selectionEntries>
                 <selectionEntry id="a087-efe7-e618-5a89" name="Select Refit" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="89a2-8f8a-1635-6818" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="89a2-8f8a-1635-6818" type="max"/>
                   </constraints>
                   <costs>
-                    <cost name="pts" typeId="points" value="5.0"/>
+                    <cost name="pts" typeId="points" value="5"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
               <costs>
-                <cost name="pts" typeId="points" value="30.0"/>
+                <cost name="pts" typeId="points" value="30"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1fc7-b047-21b3-b517" name="Ordo Hereticus" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="pts" typeId="points" value="25.0"/>
+                <cost name="pts" typeId="points" value="25"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cac1-c034-fe42-d39c" name="Ordo Malleus" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <selectionEntries>
                 <selectionEntry id="c3b5-3cf7-00c2-fa11" name="Grey Knights Terminator Boarding Party" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ea0f-367c-1884-58f6" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ea0f-367c-1884-58f6" type="max"/>
                   </constraints>
                   <costs>
-                    <cost name="pts" typeId="points" value="50.0"/>
+                    <cost name="pts" typeId="points" value="50"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="23ef-9d53-d6eb-5d01" name="Grey Knights Honour Guard" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
-                    <cost name="pts" typeId="points" value="10.0"/>
+                    <cost name="pts" typeId="points" value="10"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
               <costs>
-                <cost name="pts" typeId="points" value="25.0"/>
+                <cost name="pts" typeId="points" value="25"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3129,7 +3139,7 @@ Starhawks: 20cm</characteristic>
         <entryLink id="2039-4eff-686a-5d20" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="75.0"/>
+        <cost name="pts" typeId="points" value="75"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b598-d65f-400b-c05a" name="Dauntless Class Light Cruiser" publicationId="11f0-17d1-e4d2-1018" page="112" hidden="true" collective="false" import="true" type="model">
@@ -3138,10 +3148,10 @@ Starhawks: 20cm</characteristic>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed8-4a6a-2f2b-833d" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed8-4a6a-2f2b-833d" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -3150,27 +3160,27 @@ Starhawks: 20cm</characteristic>
       <profiles>
         <profile id="43ce-c441-2432-7f2c" name="Dauntless Profile" publicationId="11f0-17d1-e4d2-1018" page="112" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">6</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">25cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">6</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">25cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">90°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">1</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">1</characteristic>
           </characteristics>
         </profile>
         <profile id="4ada-5acb-116e-0f4a" name="Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="16a5-f857-d712-ded2" name="Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -3178,44 +3188,44 @@ Starhawks: 20cm</characteristic>
         <infoLink id="cccb-a619-cb8f-6c77" name="Improved Thrusters" hidden="false" targetId="7040-2596-65fe-10e7" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="cbc2-1d48-eb95-1afc" name="New CategoryLink" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
+        <categoryLink id="cbc2-1d48-eb95-1afc" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
         <categoryLink id="cf21-d0f7-57ad-fce7" name="CV" hidden="false" targetId="e0c6-bde4-7055-1e6e" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="9f22-9fd3-aa96-3b09" name="Prow Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="f399-20d1-105c-d652">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a145-661c-0e70-cad4" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0a1b-6c14-da99-f6dd" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a145-661c-0e70-cad4" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0a1b-6c14-da99-f6dd" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="f399-20d1-105c-d652" name="Lances (Standard)" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3af0-5c97-5cc7-5601" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3af0-5c97-5cc7-5601" type="max"/>
               </constraints>
               <profiles>
                 <profile id="a2da-a5a1-3642-381d" name="Prow Lances" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="508d-3fd6-405e-43ff" name="Havock (Torpedos)" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3f66-ca28-cbe0-d4ca" type="max"/>
-                <constraint field="selections" scope="primary-catalogue" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb83-2733-4d7d-4264" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3f66-ca28-cbe0-d4ca" type="max"/>
+                <constraint field="selections" scope="primary-catalogue" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb83-2733-4d7d-4264" type="max"/>
               </constraints>
               <profiles>
                 <profile id="46a3-21c2-d560-bb12" name="Prow Torpedos" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -3223,20 +3233,20 @@ Starhawks: 20cm</characteristic>
                 <infoLink id="8cb4-f9ec-db46-d6db" name="Torpedoes" hidden="false" targetId="8103-25d2-5412-2542" type="rule"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="067a-2ce3-5e1c-d384" name="Vigilant (Torpedos)" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="primary-catalogue" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ecee-62f4-9c55-646d" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="531c-4db6-8deb-3d49" type="max"/>
+                <constraint field="selections" scope="primary-catalogue" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ecee-62f4-9c55-646d" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="531c-4db6-8deb-3d49" type="max"/>
               </constraints>
               <profiles>
                 <profile id="d5fe-8f14-7c8e-7eea" name="Prow Torpedos" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -3244,7 +3254,7 @@ Starhawks: 20cm</characteristic>
                 <infoLink id="5402-bb69-8842-f513" name="Torpedoes" hidden="false" targetId="8103-25d2-5412-2542" type="rule"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3254,61 +3264,61 @@ Starhawks: 20cm</characteristic>
         <entryLink id="a029-0ce7-312c-fc43" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="110.0"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a2f1-7424-8ac6-fbb7" name="Omnissiah&apos;s Victory Ark Mechanicus" publicationId="b161-6b4c-e770-9ab2" page="7" hidden="true" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="decrement" field="0242-c551-15f7-beba" value="1">
           <conditions>
-            <condition field="points" scope="force" value="1000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="lessThan"/>
+            <condition field="points" scope="force" value="1000" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="lessThan"/>
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="primary-catalogue" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="0242-c551-15f7-beba" type="max"/>
+        <constraint field="selections" scope="primary-catalogue" value="1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="0242-c551-15f7-beba" type="max"/>
       </constraints>
       <profiles>
         <profile id="02e7-6d0e-b103-e950" name="Ark Mechanicus Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Battleship</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">12</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Battleship</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">12</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">4</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">6+Front/ 5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">5</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">5</characteristic>
           </characteristics>
         </profile>
         <profile id="6d54-b471-4b06-a8f4" name="Ark Mechanicus Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">10</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="9e8a-b704-d551-2230" name="Ark Mechanicus Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">10</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="2159-f7fa-0935-2c22" name="Ark Mechanicus Dorsal Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Right/Front</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Right/Front</characteristic>
           </characteristics>
         </profile>
         <profile id="d987-2e6b-e080-d079" name="Ark Mechanicus Prow Nova Cannon" hidden="false" typeId="436f6d6d616e64657223232344415441232323" typeName="Commander">
@@ -3333,18 +3343,18 @@ cannot take any other refits</characteristic>
         <infoLink id="2666-5dd1-913e-bf68" name="May not use the &quot;come to new heading&quot; special order" hidden="false" targetId="b1a1-aead-ea5a-d8d3" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="7751-75a8-eb41-fdec" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true"/>
+        <categoryLink id="7751-75a8-eb41-fdec" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true" name="Battleship"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="043b-8f01-ab42-255b" name="Broadside Armament" hidden="false" collective="false" import="true" defaultSelectionEntryId="d1cf-e37c-5cd6-3aef">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a3f6-c981-951c-c637" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2533-b44a-05e4-21e6" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a3f6-c981-951c-c637" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2533-b44a-05e4-21e6" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="bf9b-bad9-3eef-17f2" name="Launch Bays" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3c33-6ea5-c3c5-fbbf" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3c33-6ea5-c3c5-fbbf" type="max"/>
               </constraints>
               <profiles>
                 <profile id="e99d-0002-053e-7a19" name="Starboard Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
@@ -3352,7 +3362,7 @@ cannot take any other refits</characteristic>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Fury Interceptors: 30cm
 Starhawk Bombers: 20cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2 Squadrons</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="963b-e9e5-b8b7-da99" name="Port Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
@@ -3360,7 +3370,7 @@ Starhawk Bombers: 20cm</characteristic>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Fury Interceptors: 30cm
 Starhawk Bombers: 20cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2 Squadrons</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -3368,31 +3378,31 @@ Starhawk Bombers: 20cm</characteristic>
                 <entryLink id="2cb1-f4d1-51bc-2111" name="Imperial Ordnance" hidden="false" collective="false" import="true" targetId="2da3-6f87-b676-1862" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
+                <cost name="pts" typeId="points" value="10"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d1cf-e37c-5cd6-3aef" name="Lance Batteries" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ed14-cd0a-8801-9754" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ed14-cd0a-8801-9754" type="max"/>
               </constraints>
               <profiles>
                 <profile id="e154-019c-52e0-e6d6" name="Ark Mechanicus Port Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="faad-e968-30d1-7a9d" name="Ark Mechanicus Starboard Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3402,7 +3412,7 @@ Starhawk Bombers: 20cm</characteristic>
         <entryLink id="9cb1-ee6c-3873-6a6d" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="415.0"/>
+        <cost name="pts" typeId="points" value="415"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1e58-45bd-51ae-d140" name="Archmagos" page="0" hidden="true" collective="false" import="true" type="upgrade">
@@ -3411,8 +3421,8 @@ Starhawk Bombers: 20cm</characteristic>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2f1-7424-8ac6-fbb7" type="equalTo"/>
-                <condition field="points" scope="force" value="999.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2f1-7424-8ac6-fbb7" type="equalTo"/>
+                <condition field="points" scope="force" value="999" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="greaterThan"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -3421,25 +3431,25 @@ Starhawk Bombers: 20cm</characteristic>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="ff52-0b6e-7331-a047" type="min"/>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="a85c-9089-f571-4daf" type="max"/>
+        <constraint field="selections" scope="roster" value="0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="ff52-0b6e-7331-a047" type="min"/>
+        <constraint field="selections" scope="roster" value="1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="a85c-9089-f571-4daf" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="4425-8d65-491a-a447" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="true"/>
+        <categoryLink id="4425-8d65-491a-a447" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="true" name="Fleet Commander"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="9eac-bb43-252b-eca9" name="Rank" hidden="false" collective="false" import="true" defaultSelectionEntryId="c0c4-067d-7dfe-c3b7">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ba2f-5785-95b7-8688" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e265-c3a2-9aa2-4f4d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ba2f-5785-95b7-8688" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e265-c3a2-9aa2-4f4d" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="c0c4-067d-7dfe-c3b7" name="Explorator" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3448,12 +3458,12 @@ Starhawk Bombers: 20cm</characteristic>
                   <modifiers>
                     <modifier type="increment" field="52652d726f6c6c7323232344415441232323" value="1">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="385f-4431-c676-d2cb" type="instanceOf"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="385f-4431-c676-d2cb" type="instanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="52652d726f6c6c7323232344415441232323" value="2">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e391-485e-06e1-1de2" type="instanceOf"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e391-485e-06e1-1de2" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -3467,54 +3477,54 @@ Starhawk Bombers: 20cm</characteristic>
               <selectionEntryGroups>
                 <selectionEntryGroup id="982b-330b-1cfd-9281" name="Re-Rolls" hidden="false" collective="false" import="true">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7627-1dea-a5c6-6c35" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7627-1dea-a5c6-6c35" type="max"/>
                   </constraints>
                   <selectionEntries>
                     <selectionEntry id="385f-4431-c676-d2cb" name="1 Re-Roll" page="0" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9c9f-adc3-de42-465e" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9c9f-adc3-de42-465e" type="max"/>
                       </constraints>
                       <costs>
-                        <cost name="pts" typeId="points" value="50.0"/>
+                        <cost name="pts" typeId="points" value="50"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="e391-485e-06e1-1de2" name="2 Re-Rolls" page="0" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="214d-2ff1-37e7-32e3" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="214d-2ff1-37e7-32e3" type="max"/>
                       </constraints>
                       <costs>
-                        <cost name="pts" typeId="points" value="125.0"/>
+                        <cost name="pts" typeId="points" value="125"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="pts" typeId="points" value="50.0"/>
+                <cost name="pts" typeId="points" value="50"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="caa7-4b39-7cea-98c2" name="Veneratus" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="7494-af44-7d83-a190" value="1">
                   <conditions>
-                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2f1-7424-8ac6-fbb7" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2f1-7424-8ac6-fbb7" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7494-af44-7d83-a190" type="min"/>
+                <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7494-af44-7d83-a190" type="min"/>
               </constraints>
               <profiles>
                 <profile id="0eba-11ee-760f-c3f3" name="Veneratus" hidden="false" typeId="436f6d6d616e64657223232344415441232323" typeName="Commander">
                   <modifiers>
                     <modifier type="increment" field="52652d726f6c6c7323232344415441232323" value="1">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8e8-922f-d133-f964" type="instanceOf"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8e8-922f-d133-f964" type="instanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="52652d726f6c6c7323232344415441232323" value="2">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="358c-bf6b-2ea3-4585" type="instanceOf"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="358c-bf6b-2ea3-4585" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -3528,30 +3538,30 @@ Starhawk Bombers: 20cm</characteristic>
               <selectionEntryGroups>
                 <selectionEntryGroup id="1e46-0ce7-1bab-18fe" name="Re-Rolls" hidden="false" collective="false" import="true">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6011-da9f-d6d3-08ce" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6011-da9f-d6d3-08ce" type="max"/>
                   </constraints>
                   <selectionEntries>
                     <selectionEntry id="b8e8-922f-d133-f964" name="1 Re-Roll" page="0" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="02c0-a341-b5a1-d0a8" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="02c0-a341-b5a1-d0a8" type="max"/>
                       </constraints>
                       <costs>
-                        <cost name="pts" typeId="points" value="50.0"/>
+                        <cost name="pts" typeId="points" value="50"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="358c-bf6b-2ea3-4585" name="2 Re-Rolls" page="0" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c256-81a8-f414-a5a4" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c256-81a8-f414-a5a4" type="max"/>
                       </constraints>
                       <costs>
-                        <cost name="pts" typeId="points" value="125.0"/>
+                        <cost name="pts" typeId="points" value="125"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="pts" typeId="points" value="100.0"/>
+                <cost name="pts" typeId="points" value="100"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3561,27 +3571,27 @@ Starhawk Bombers: 20cm</characteristic>
         <entryLink id="3e11-8235-be7d-84d8" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="be36-cf2d-5993-dbc5" name="Gothic Class Cruiser" publicationId="11f0-17d1-e4d2-1018" page="111" hidden="true" collective="false" import="true" type="model">
       <modifiers>
-        <modifier type="increment" field="points" value="35.0">
+        <modifier type="increment" field="points" value="35">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed8-4a6a-2f2b-833d" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed8-4a6a-2f2b-833d" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -3590,39 +3600,39 @@ Starhawk Bombers: 20cm</characteristic>
       <profiles>
         <profile id="0d7f-b8f9-9ae3-14b5" name="Gothic Profile" publicationId="11f0-17d1-e4d2-1018" page="111" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <modifiers>
-            <modifier type="increment" field="5475727265747323232344415441232323" value="1">
+            <modifier type="increment" field="5.475727265747323e+33" value="1">
               <conditions>
-                <condition field="selections" scope="be36-cf2d-5993-dbc5" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8025-e5ea-9b7b-7f59" type="atLeast"/>
+                <condition field="selections" scope="be36-cf2d-5993-dbc5" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8025-e5ea-9b7b-7f59" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">8</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">8</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">2</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">6+Front/ 5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">2</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">2</characteristic>
           </characteristics>
         </profile>
         <profile id="0044-9a26-6ea8-9637" name="Gothic Port Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="3abb-7acd-60fb-a20a" name="Gothic Starboard Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="d114-52f9-6672-b0ea" name="New CategoryLink" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
+        <categoryLink id="d114-52f9-6672-b0ea" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
         <categoryLink id="24ef-6865-a11d-201a" name="CV" hidden="false" targetId="e0c6-bde4-7055-1e6e" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -3630,35 +3640,35 @@ Starhawk Bombers: 20cm</characteristic>
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4101-3da3-6147-8c99" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4101-3da3-6147-8c99" type="max"/>
           </constraints>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="e864-686d-8151-0a1a" name="Prow Weapons Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="ef50-bc38-0b85-d13e">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4479-39ff-0e1c-22af" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bc9b-c85e-e789-9bae" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4479-39ff-0e1c-22af" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bc9b-c85e-e789-9bae" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="ef50-bc38-0b85-d13e" name="Prow Torpedoes" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2b58-c501-aecc-2410" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2b58-c501-aecc-2410" type="max"/>
               </constraints>
               <profiles>
                 <profile id="0842-8442-c298-f71f" name="Prow Torpedoes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -3666,7 +3676,7 @@ Starhawk Bombers: 20cm</characteristic>
                 <infoLink id="9334-9bb4-8b8f-3242" name="Torpedoes" hidden="false" targetId="8103-25d2-5412-2542" type="rule"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3675,7 +3685,7 @@ Starhawk Bombers: 20cm</characteristic>
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -3689,27 +3699,27 @@ Starhawk Bombers: 20cm</characteristic>
         <entryLink id="9d70-9863-9bcc-4395" name="Bakka Turret" hidden="false" collective="false" import="true" targetId="8025-e5ea-9b7b-7f59" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="180.0"/>
+        <cost name="pts" typeId="points" value="180"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7cdb-036c-41b6-ca4e" name="Lunar Class Cruiser" publicationId="11f0-17d1-e4d2-1018" page="110" hidden="true" collective="false" import="true" type="model">
       <modifiers>
-        <modifier type="increment" field="points" value="35.0">
+        <modifier type="increment" field="points" value="35">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed8-4a6a-2f2b-833d" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed8-4a6a-2f2b-833d" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -3718,58 +3728,58 @@ Starhawk Bombers: 20cm</characteristic>
       <profiles>
         <profile id="0822-73c1-630e-4f33" name="Lunar Profile" publicationId="11f0-17d1-e4d2-1018" page="110" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <modifiers>
-            <modifier type="increment" field="5475727265747323232344415441232323" value="1">
+            <modifier type="increment" field="5.475727265747323e+33" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5b6b-2f04-0be9-7e1e" type="instanceOf"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5b6b-2f04-0be9-7e1e" type="instanceOf"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="5475727265747323232344415441232323" value="1">
+            <modifier type="increment" field="5.475727265747323e+33" value="1">
               <conditions>
-                <condition field="selections" scope="7cdb-036c-41b6-ca4e" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8025-e5ea-9b7b-7f59" type="atLeast"/>
+                <condition field="selections" scope="7cdb-036c-41b6-ca4e" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8025-e5ea-9b7b-7f59" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">8</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">8</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">2</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">6+Front/ 5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">2</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">2</characteristic>
           </characteristics>
         </profile>
         <profile id="9c85-5d59-5df2-191d" name="Lunar Port Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="89b5-11e6-67e4-a4f7" name="Lunar Starboard Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="0988-dbbc-eade-ca48" name="Lunar Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="7605-8e7a-5a1a-fd5d" name="Lunar Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="ac0c-cd58-9d9a-775e" name="New CategoryLink" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
+        <categoryLink id="ac0c-cd58-9d9a-775e" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
         <categoryLink id="249f-4ba8-ce46-cfcb" name="CV" hidden="false" targetId="e0c6-bde4-7055-1e6e" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -3777,61 +3787,61 @@ Starhawk Bombers: 20cm</characteristic>
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c146-206e-4325-2aa8" type="max"/>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0eb8-be24-6d27-df57" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c146-206e-4325-2aa8" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0eb8-be24-6d27-df57" type="min"/>
           </constraints>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="b706-1685-87e3-1fc4" name="Prow Weapons Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="574a-6346-ad91-19a1">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c12d-6273-ce99-174d" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e5f6-8cb2-793a-be45" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c12d-6273-ce99-174d" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e5f6-8cb2-793a-be45" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="37e3-6940-cade-7479" name="Lord Daros (Prow Nova)" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="267d-a72f-3e7d-fdbb" type="max"/>
-                <constraint field="selections" scope="primary-catalogue" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="adba-a561-38d4-903f" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="267d-a72f-3e7d-fdbb" type="max"/>
+                <constraint field="selections" scope="primary-catalogue" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="adba-a561-38d4-903f" type="max"/>
               </constraints>
               <profiles>
                 <profile id="ab40-238e-8f5e-fc7f" name="Prow Nova Cannon" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30-150</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
+                <cost name="pts" typeId="points" value="20"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="574a-6346-ad91-19a1" name="Torpedoes" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0d84-a67e-108f-18a5" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0d84-a67e-108f-18a5" type="max"/>
               </constraints>
               <profiles>
                 <profile id="ff64-2c94-69ea-8767" name="Prow Torpedoes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -3839,32 +3849,32 @@ Starhawk Bombers: 20cm</characteristic>
                 <infoLink id="fa0f-6423-2dee-2486" name="Torpedoes" hidden="false" targetId="8103-25d2-5412-2542" type="rule"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d785-676e-4c5c-edee" name="Minotaur (Prow Nova)" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0f28-259c-98cb-3cdb" type="max"/>
-                <constraint field="selections" scope="primary-catalogue" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6dfc-4f0d-48a9-fdf9" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0f28-259c-98cb-3cdb" type="max"/>
+                <constraint field="selections" scope="primary-catalogue" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6dfc-4f0d-48a9-fdf9" type="max"/>
               </constraints>
               <profiles>
                 <profile id="86b9-8c33-d50a-78ea" name="Prow Nova Cannon" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <modifiers>
                     <modifier type="set" field="hidden" value="true">
                       <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30-150</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
+                <cost name="pts" typeId="points" value="20"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3873,7 +3883,7 @@ Starhawk Bombers: 20cm</characteristic>
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -3884,7 +3894,7 @@ Starhawk Bombers: 20cm</characteristic>
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -3900,27 +3910,27 @@ Starhawk Bombers: 20cm</characteristic>
         <entryLink id="2043-75a4-0832-71ac" name="Bakka Turret" hidden="false" collective="false" import="true" targetId="8025-e5ea-9b7b-7f59" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="180.0"/>
+        <cost name="pts" typeId="points" value="180"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="07f4-ad3c-5819-a030" name="Tyrant Class Cruiser" publicationId="11f0-17d1-e4d2-1018" page="110" hidden="true" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="increment" field="points" value="35">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed8-4a6a-2f2b-833d" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed8-4a6a-2f2b-833d" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -3929,44 +3939,44 @@ Starhawk Bombers: 20cm</characteristic>
       <profiles>
         <profile id="e469-32f4-cedf-0394" name="Tyrant Profile" publicationId="11f0-17d1-e4d2-1018" page="110" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <modifiers>
-            <modifier type="increment" field="5475727265747323232344415441232323" value="1">
+            <modifier type="increment" field="5.475727265747323e+33" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="aefd-bfd2-2dbf-0318" type="instanceOf"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="aefd-bfd2-2dbf-0318" type="instanceOf"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="5475727265747323232344415441232323" value="1">
+            <modifier type="increment" field="5.475727265747323e+33" value="1">
               <conditions>
-                <condition field="selections" scope="07f4-ad3c-5819-a030" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8025-e5ea-9b7b-7f59" type="atLeast"/>
+                <condition field="selections" scope="07f4-ad3c-5819-a030" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8025-e5ea-9b7b-7f59" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">8</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">8</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">2</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">6+Front/ 5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">2</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">2</characteristic>
           </characteristics>
         </profile>
         <profile id="a4da-b2ec-4516-a6f3" name="Tyrant Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="3061-82c1-50e7-f0a5" name="Tyrant Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="ff89-6bbc-94db-49c7" name="New CategoryLink" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
+        <categoryLink id="ff89-6bbc-94db-49c7" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
         <categoryLink id="2ada-d0c9-7fd2-0bf3" name="CV" hidden="false" targetId="e0c6-bde4-7055-1e6e" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -3974,71 +3984,71 @@ Starhawk Bombers: 20cm</characteristic>
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fe76-f64b-9d6c-94b1" type="max"/>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0503-e6b0-2d33-0933" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fe76-f64b-9d6c-94b1" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0503-e6b0-2d33-0933" type="min"/>
           </constraints>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="5461-3ba9-c701-129b" name="Varient" hidden="false" collective="false" import="true" defaultSelectionEntryId="d4c1-159f-9020-f1f2">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="deab-58ac-e594-63e3" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ca0-2ff0-36de-4d15" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="deab-58ac-e594-63e3" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ca0-2ff0-36de-4d15" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="13ba-a064-0fb4-607d" name="Dominion (45cm WB)" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1820-aa5b-cca1-9ae2" type="max"/>
-                <constraint field="selections" scope="primary-catalogue" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a82-ed3d-4e76-918b" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1820-aa5b-cca1-9ae2" type="max"/>
+                <constraint field="selections" scope="primary-catalogue" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a82-ed3d-4e76-918b" type="max"/>
               </constraints>
               <profiles>
                 <profile id="b923-8f37-964f-87ec" name="Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="529e-0fbc-2bef-ced5" name="Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <selectionEntryGroups>
                 <selectionEntryGroup id="3d52-f5cd-c437-2934" name="Prow Weapons Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="fdc2-f0aa-ef75-8dd3">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="db76-d1a7-a0b6-d5e6" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="217f-dc42-9845-a46d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="db76-d1a7-a0b6-d5e6" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="217f-dc42-9845-a46d" type="max"/>
                   </constraints>
                   <selectionEntries>
                     <selectionEntry id="fdc2-f0aa-ef75-8dd3" name="Prow Torpedoes" page="0" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="571d-a245-b413-b70c" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="571d-a245-b413-b70c" type="max"/>
                       </constraints>
                       <profiles>
                         <profile id="88ac-2e19-7e2e-37b9" name="Prow Torpedoes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                           <characteristics>
                             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                           </characteristics>
                         </profile>
                       </profiles>
@@ -4046,53 +4056,53 @@ Starhawk Bombers: 20cm</characteristic>
                         <infoLink id="dda2-cb7a-3f7e-ed8e" name="Torpedoes" hidden="false" targetId="8103-25d2-5412-2542" type="rule"/>
                       </infoLinks>
                       <costs>
-                        <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name="pts" typeId="points" value="0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
+                <cost name="pts" typeId="points" value="10"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d4c1-159f-9020-f1f2" name="Standard" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61dd-c42f-0152-cb43" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61dd-c42f-0152-cb43" type="max"/>
               </constraints>
               <profiles>
                 <profile id="8c33-f109-66b5-fde4" name="Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="d7ea-d220-73e9-8c1b" name="Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <selectionEntryGroups>
                 <selectionEntryGroup id="427f-2c41-46f2-3b5b" name="Prow Weapons Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="a241-c924-0c94-e72e">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8579-882b-f9f2-70e6" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7768-fca9-6441-42b9" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8579-882b-f9f2-70e6" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7768-fca9-6441-42b9" type="max"/>
                   </constraints>
                   <selectionEntries>
                     <selectionEntry id="a241-c924-0c94-e72e" name="Prow Torpedoes" page="0" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="328d-2ad7-6e78-3788" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="328d-2ad7-6e78-3788" type="max"/>
                       </constraints>
                       <profiles>
                         <profile id="8a6a-27f7-850e-d5a6" name="Prow Torpedoes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                           <characteristics>
                             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                           </characteristics>
                         </profile>
                       </profiles>
@@ -4100,24 +4110,24 @@ Starhawk Bombers: 20cm</characteristic>
                         <infoLink id="5495-266d-fae1-7662" name="Torpedoes" hidden="false" targetId="8103-25d2-5412-2542" type="rule"/>
                       </infoLinks>
                       <costs>
-                        <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name="pts" typeId="points" value="0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="c95c-b452-2bf9-341f" name="Prow Nova" page="0" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a73e-5e71-dca1-60cb" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a73e-5e71-dca1-60cb" type="max"/>
                       </constraints>
                       <profiles>
                         <profile id="565e-bde3-a785-e946" name="Prow Nova Cannon" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                           <characteristics>
                             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30-150</characteristic>
                             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1</characteristic>
-                            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                           </characteristics>
                         </profile>
                       </profiles>
                       <costs>
-                        <cost name="pts" typeId="points" value="20.0"/>
+                        <cost name="pts" typeId="points" value="20"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -4126,7 +4136,7 @@ Starhawk Bombers: 20cm</characteristic>
                       <modifiers>
                         <modifier type="set" field="hidden" value="false">
                           <conditions>
-                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
                           </conditions>
                         </modifier>
                       </modifiers>
@@ -4135,54 +4145,54 @@ Starhawk Bombers: 20cm</characteristic>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6006-f305-9563-5347" name="Zealous (45cm WB and Nova Option)" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c321-b684-cdfb-bb0f" type="max"/>
-                <constraint field="selections" scope="primary-catalogue" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b42-b299-3f09-8f0a" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c321-b684-cdfb-bb0f" type="max"/>
+                <constraint field="selections" scope="primary-catalogue" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b42-b299-3f09-8f0a" type="max"/>
               </constraints>
               <profiles>
                 <profile id="362a-dae0-5cf2-f235" name="Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="b2eb-eafa-7555-9996" name="Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <selectionEntryGroups>
                 <selectionEntryGroup id="4e74-6bbb-d222-43dd" name="Prow Weapons Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="197b-53e3-c4ee-78e2">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3148-1557-fd8c-bd89" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5faa-d515-1c2e-b77c" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3148-1557-fd8c-bd89" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5faa-d515-1c2e-b77c" type="max"/>
                   </constraints>
                   <selectionEntries>
                     <selectionEntry id="197b-53e3-c4ee-78e2" name="Prow Torpedoes" page="0" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8827-97e0-1377-8e80" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8827-97e0-1377-8e80" type="max"/>
                       </constraints>
                       <profiles>
                         <profile id="aa21-6b4a-890e-def6" name="Prow Torpedoes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                           <characteristics>
                             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                           </characteristics>
                         </profile>
                       </profiles>
@@ -4190,24 +4200,24 @@ Starhawk Bombers: 20cm</characteristic>
                         <infoLink id="3f16-5254-ee39-a25a" name="Torpedoes" hidden="false" targetId="8103-25d2-5412-2542" type="rule"/>
                       </infoLinks>
                       <costs>
-                        <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name="pts" typeId="points" value="0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="b664-6587-debb-d2ec" name="Zealous Prow Nova" page="0" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="230a-1f21-5713-9b0b" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="230a-1f21-5713-9b0b" type="max"/>
                       </constraints>
                       <profiles>
                         <profile id="0459-a3c4-64d6-8a6e" name="Prow Nova Cannon" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                           <characteristics>
                             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30-150</characteristic>
                             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1</characteristic>
-                            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                           </characteristics>
                         </profile>
                       </profiles>
                       <costs>
-                        <cost name="pts" typeId="points" value="20.0"/>
+                        <cost name="pts" typeId="points" value="20"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -4216,7 +4226,7 @@ Starhawk Bombers: 20cm</characteristic>
                       <modifiers>
                         <modifier type="set" field="hidden" value="false">
                           <conditions>
-                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
                           </conditions>
                         </modifier>
                       </modifiers>
@@ -4225,7 +4235,7 @@ Starhawk Bombers: 20cm</characteristic>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
+                <cost name="pts" typeId="points" value="10"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4237,7 +4247,7 @@ Starhawk Bombers: 20cm</characteristic>
         <entryLink id="7563-e759-95aa-396d" name="Power Ram" hidden="false" collective="false" import="true" targetId="9818-379a-5217-d9e9" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="185.0"/>
+        <cost name="pts" typeId="points" value="185"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1db1-a0a2-2bd7-5a2a" name="Space Marine Fortress Monastary" publicationId="5766-7751-d146-0800" page="55" hidden="true" collective="false" import="true" type="model">
@@ -4246,60 +4256,60 @@ Starhawk Bombers: 20cm</characteristic>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="primary-catalogue" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f1a0-d2b5-cbae-c5e0" type="max"/>
+        <constraint field="selections" scope="primary-catalogue" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f1a0-d2b5-cbae-c5e0" type="max"/>
       </constraints>
       <profiles>
         <profile id="3f92-f443-a053-c80e" name="Fortress Monastary Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Defense</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">12 per Quadrant</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">0cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Defense</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">12 per Quadrant</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">0cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">0°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">4 per Quadrant</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">6+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">4 per Quadrant</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">4 per Quadrant</characteristic>
           </characteristics>
         </profile>
         <profile id="49eb-c5d3-a394-ea91" name="Basilica Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">8</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">All Round</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">All Round</characteristic>
           </characteristics>
         </profile>
         <profile id="e37c-7f84-5a6c-12ec" name="Basilica Torpedo Silos" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">9</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">All Round</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">All Round</characteristic>
           </characteristics>
         </profile>
         <profile id="8097-ea8f-e5ec-9686" name="Quadrant Weapons Battery (1 per Quadrant)" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">18</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Quadrant</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Quadrant</characteristic>
           </characteristics>
         </profile>
         <profile id="8f75-f750-6f4e-9083" name="Quadrant Lance Battery (1 per Quadrant)" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Quadrant</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Quadrant</characteristic>
           </characteristics>
         </profile>
         <profile id="ee86-8e5a-7f10-b070" name="Quadrant Launch Bays (1 per Quadrant)" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Thunderhawks: 20cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3 Squadrons</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -4310,13 +4320,13 @@ Starhawk Bombers: 20cm</characteristic>
         <infoLink id="b3b4-491c-bad8-9459" name="Torpedoes" hidden="false" targetId="8103-25d2-5412-2542" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="f0e5-43a0-c025-4ed0" name="New CategoryLink" hidden="false" targetId="5370656369616c23232344415441232323" primary="true"/>
+        <categoryLink id="f0e5-43a0-c025-4ed0" name="Special" hidden="false" targetId="5370656369616c23232344415441232323" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="1681-c83f-03b3-e5a8" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="1000.0"/>
+        <cost name="pts" typeId="points" value="1000"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f567-535a-0c79-c2f5" name="Daemon Slayer Class Cruiser" hidden="true" collective="false" import="true" type="model">
@@ -4325,7 +4335,7 @@ Starhawk Bombers: 20cm</characteristic>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -4334,39 +4344,39 @@ Starhawk Bombers: 20cm</characteristic>
       <profiles>
         <profile id="3c7f-e632-1dd2-39b5" name="Daemon Slayer Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">8</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">8</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">2</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">6+Front/5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">3</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">3</characteristic>
           </characteristics>
         </profile>
         <profile id="ea9b-e631-e536-1ae2" name="Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">10</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="a2d8-253b-30d2-815d" name="Starboard Weapons battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">10</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="3ec5-0a83-fecb-9327" name="Prow Psychic Cannon" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="4fba-87f5-c68b-a8ae" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
+        <categoryLink id="4fba-87f5-c68b-a8ae" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
         <categoryLink id="19c1-7590-65ce-a3b8" name="CV" hidden="false" targetId="e0c6-bde4-7055-1e6e" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -4374,7 +4384,7 @@ Starhawk Bombers: 20cm</characteristic>
         <entryLink id="6ae1-65e2-9c5f-b9da" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="170.0"/>
+        <cost name="pts" typeId="points" value="170"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8219-a790-d336-edc0" name="Enforcer Class System Control Cruiser" hidden="true" collective="false" import="true" type="model">
@@ -4383,7 +4393,7 @@ Starhawk Bombers: 20cm</characteristic>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -4392,20 +4402,20 @@ Starhawk Bombers: 20cm</characteristic>
       <profiles>
         <profile id="e80c-6e3d-f469-5a6c" name="Enforcer Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">6</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">25cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">6</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">25cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">90°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">2</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">2</characteristic>
           </characteristics>
         </profile>
         <profile id="8937-f183-8da9-0517" name="Prow Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
           </characteristics>
         </profile>
         <profile id="d092-6fc6-8c09-e972" name="Port Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
@@ -4413,7 +4423,7 @@ Starhawk Bombers: 20cm</characteristic>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Starhawks: 20cm
 Furies: 30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1 Squadron</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
         <profile id="61bb-8a0f-6031-840c" name="Starboard Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
@@ -4421,12 +4431,12 @@ Furies: 30cm</characteristic>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Starhawks: 20cm
 Furies: 30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1 Squadron</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="9b5a-6890-4e8f-e7ca" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
+        <categoryLink id="9b5a-6890-4e8f-e7ca" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
         <categoryLink id="b5e9-4dcf-827a-9fb6" name="CV" hidden="false" targetId="e0c6-bde4-7055-1e6e" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -4434,7 +4444,7 @@ Furies: 30cm</characteristic>
         <entryLink id="bca6-a651-a0c8-6e32" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="130.0"/>
+        <cost name="pts" typeId="points" value="130"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0dd5-721a-7c40-137d" name="Defender Class Escort Cruiser" hidden="true" collective="false" import="true" type="model">
@@ -4443,7 +4453,7 @@ Furies: 30cm</characteristic>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -4452,53 +4462,53 @@ Furies: 30cm</characteristic>
       <profiles>
         <profile id="8996-5292-9907-cd38" name="Defender Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">6</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">25cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">6</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">25cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">90°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">2</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">2</characteristic>
           </characteristics>
         </profile>
         <profile id="92c2-e848-f76c-61be" name="Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="3a22-2883-74c1-21c3" name="Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="b4b2-1e5a-a89d-f5cb" name="Dorsal Fleet Defence Turret" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">15cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
         <profile id="7157-0f0e-c3c3-75a9" name="Prow Lances" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="9d21-c50c-debf-4d41" name="New CategoryLink" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
+        <categoryLink id="9d21-c50c-debf-4d41" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
         <categoryLink id="c9bd-023e-5e0a-6e19" name="CV" hidden="false" targetId="e0c6-bde4-7055-1e6e" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="ce07-b626-9b40-c56c" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="120.0"/>
+        <cost name="pts" typeId="points" value="120"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3985-5bfc-9673-b1f2" name="Fast Clipper" publicationId="9670-79b6-b335-ed60" hidden="true" collective="false" import="true" type="model">
@@ -4507,8 +4517,8 @@ Furies: 30cm</characteristic>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -4517,20 +4527,20 @@ Furies: 30cm</characteristic>
       <profiles>
         <profile id="8aa7-07ee-11de-9f45" name="Fast Clipper Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <modifiers>
-            <modifier type="set" field="537065656423232344415441232323" value="25cm">
+            <modifier type="set" field="5.370656564232324e+29" value="25cm">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8503-3976-d32c-abb3" type="instanceOf"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8503-3976-d32c-abb3" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Escort</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">1</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">30cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Escort</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">1</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">30cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">90°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">1</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">1</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -4538,47 +4548,47 @@ Furies: 30cm</characteristic>
         <infoLink id="a94f-d1af-2d82-5af1" name="Improved Thrusters" hidden="false" targetId="7040-2596-65fe-10e7" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="a9af-47fd-15c8-663e" name="New CategoryLink" hidden="false" targetId="4573636f72747323232344415441232323" primary="true"/>
+        <categoryLink id="a9af-47fd-15c8-663e" name="Escort" hidden="false" targetId="4573636f72747323232344415441232323" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="dab8-3569-1f2e-5d8b" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="8c3c-5cd4-f359-7ccb">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23c2-4044-b54e-f20e" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bd2-15c0-04bb-0f2f" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23c2-4044-b54e-f20e" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bd2-15c0-04bb-0f2f" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="8c3c-5cd4-f359-7ccb" name="None" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48cc-fd51-ea1f-9cf1" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48cc-fd51-ea1f-9cf1" type="max"/>
               </constraints>
               <profiles>
                 <profile id="3a21-076b-abc9-52e0" name="None" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">None</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">None</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8503-3976-d32c-abb3" name="Dorsal Weapons Battery (-5cm Speed)" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3592-f84c-70c8-fd9e" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3592-f84c-70c8-fd9e" type="max"/>
               </constraints>
               <profiles>
                 <profile id="a27a-ce26-23ae-35d6" name="Dorsal Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">15cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4588,7 +4598,7 @@ Furies: 30cm</characteristic>
         <entryLink id="d3a5-f82a-fd3e-1260" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="30.0"/>
+        <cost name="pts" typeId="points" value="30"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="01c8-494d-9255-28f1" name="Galaxy Class Armed Freighter" hidden="true" collective="false" import="true" type="model">
@@ -4597,8 +4607,8 @@ Furies: 30cm</characteristic>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -4607,20 +4617,20 @@ Furies: 30cm</characteristic>
       <profiles>
         <profile id="36c9-7075-8e71-dc8b" name="Galaxy Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Escort</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">1</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">15cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Escort</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">1</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">15cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">1</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">1</characteristic>
           </characteristics>
         </profile>
         <profile id="b49d-1531-5d09-7a7b" name="Dorsal Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -4628,13 +4638,13 @@ Furies: 30cm</characteristic>
         <rule id="79ab-1594-1838-1129" name="&quot;All Ahead Full&quot; limited to +3D6 and -1Ld" hidden="false"/>
       </rules>
       <categoryLinks>
-        <categoryLink id="a1c8-b2dc-f3d0-8fda" name="New CategoryLink" hidden="false" targetId="4573636f72747323232344415441232323" primary="true"/>
+        <categoryLink id="a1c8-b2dc-f3d0-8fda" name="Escort" hidden="false" targetId="4573636f72747323232344415441232323" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="5460-1faf-04e0-d5b7" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="20.0"/>
+        <cost name="pts" typeId="points" value="20"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3389-e8ea-ac1a-2f67" name="Tarask Class Merchantman" hidden="true" collective="false" import="true" type="model">
@@ -4643,7 +4653,7 @@ Furies: 30cm</characteristic>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -4652,31 +4662,31 @@ Furies: 30cm</characteristic>
       <profiles>
         <profile id="7b64-c1fd-2513-ba5a" name="Tarask Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Escort</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">1</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Escort</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">1</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">1</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">1</characteristic>
           </characteristics>
         </profile>
         <profile id="b39f-1b9d-ff4e-560a" name="Dorsal Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="14e1-4f21-21e9-c6bd" name="New CategoryLink" hidden="false" targetId="4573636f72747323232344415441232323" primary="true"/>
+        <categoryLink id="14e1-4f21-21e9-c6bd" name="Escort" hidden="false" targetId="4573636f72747323232344415441232323" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="a559-18bb-d68b-5524" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="20.0"/>
+        <cost name="pts" typeId="points" value="20"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7e4e-bf81-101c-1633" name="Goliath Class Forge Tender" hidden="true" collective="false" import="true" type="model">
@@ -4685,7 +4695,7 @@ Furies: 30cm</characteristic>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -4694,34 +4704,34 @@ Furies: 30cm</characteristic>
       <profiles>
         <profile id="ad43-7bb5-f374-4023" name="Goliath Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">6</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">15cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">6</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">15cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">2</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">2</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">2</characteristic>
           </characteristics>
         </profile>
         <profile id="c184-7c46-05ea-283f" name="Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">15cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="905e-1e5c-1878-4e85" name="Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">15cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="ecc9-8f73-50d3-a643" name="Dorsal Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">15cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -4730,14 +4740,14 @@ Furies: 30cm</characteristic>
         <rule id="d28f-6c8a-b8b1-2361" name="Repair 1 damage point after beeing in base contact with another ship for one full turn (including itself) if not crippled" hidden="false"/>
       </rules>
       <categoryLinks>
-        <categoryLink id="70c9-5724-3d64-9d02" name="New CategoryLink" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
+        <categoryLink id="70c9-5724-3d64-9d02" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
         <categoryLink id="2367-ad4f-7177-d20a" name="CV" hidden="false" targetId="e0c6-bde4-7055-1e6e" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="af16-dd4d-5b06-19f9" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="30.0"/>
+        <cost name="pts" typeId="points" value="30"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="be6d-4e6a-8294-c768" name="Super Heavy Troop Transport" hidden="true" collective="false" import="true" type="model">
@@ -4746,8 +4756,8 @@ Furies: 30cm</characteristic>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -4756,20 +4766,20 @@ Furies: 30cm</characteristic>
       <profiles>
         <profile id="e2c5-d084-4cf2-107b" name="Superheavy Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">2</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">15cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">2</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">15cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">1</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">1</characteristic>
           </characteristics>
         </profile>
         <profile id="0207-5950-3de2-cb0e" name="Dorsal Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">15cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -4777,14 +4787,14 @@ Furies: 30cm</characteristic>
         <rule id="e2d5-dad1-e4a1-d0b1" name="&quot;All Ahead Full&quot; limited to +3D6 and -1Ld" hidden="false"/>
       </rules>
       <categoryLinks>
-        <categoryLink id="812a-28e2-8e97-2efa" name="New CategoryLink" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
+        <categoryLink id="812a-28e2-8e97-2efa" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
         <categoryLink id="3a7a-b3e5-a912-2c2d" name="CV" hidden="false" targetId="e0c6-bde4-7055-1e6e" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="c939-d6cf-452a-2543" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ca56-85e4-948d-b91b" name="Super Heavy Fuel Transport" hidden="true" collective="false" import="true" type="model">
@@ -4793,7 +4803,7 @@ Furies: 30cm</characteristic>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -4802,20 +4812,20 @@ Furies: 30cm</characteristic>
       <profiles>
         <profile id="b84a-6b26-47c9-de49" name="Super Heavy Fuel Transport" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">2</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">15cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">2</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">15cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">1</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">1</characteristic>
           </characteristics>
         </profile>
         <profile id="3247-9ba6-8b31-0167" name="Dorsal Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">15cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
         <profile id="cd3a-bbb0-cd18-7294" name="Volatile Cargo" hidden="false" typeId="5a49-6569-78e9-a35c" typeName="Special Rule">
@@ -4830,54 +4840,54 @@ When rolling on the Catastrophic Damage table also add +2 tothe dice roll. The m
         <rule id="989c-f299-3df2-a924" name="&quot;All Ahead Full&quot; limited to +3D6 and -1Ld" hidden="false"/>
       </rules>
       <categoryLinks>
-        <categoryLink id="834f-e0b6-f1e8-866a" name="New CategoryLink" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
+        <categoryLink id="834f-e0b6-f1e8-866a" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
         <categoryLink id="6ca1-0d58-e4d6-e731" name="CV" hidden="false" targetId="e0c6-bde4-7055-1e6e" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="9181-ccb1-c4f8-bc11" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="935e-991e-f1df-8706" name="Pirate Captain" page="" hidden="true" collective="false" import="true" type="upgrade">
+    <selectionEntry id="935e-991e-f1df-8706" name="Pirate Captain" hidden="true" collective="false" import="true" type="upgrade">
       <modifiers>
-        <modifier type="increment" field="ea9d-9b95-9365-d858" value="1.0">
+        <modifier type="increment" field="ea9d-9b95-9365-d858" value="1">
           <conditions>
-            <condition field="points" scope="force" value="500.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="greaterThan"/>
+            <condition field="points" scope="force" value="500" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="greaterThan"/>
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
-        <modifier type="increment" field="c5a3-1633-8e2b-1240" value="1.0">
+        <modifier type="increment" field="c5a3-1633-8e2b-1240" value="1">
           <conditions>
-            <condition field="points" scope="force" value="750.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="greaterThan"/>
+            <condition field="points" scope="force" value="750" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="greaterThan"/>
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea9d-9b95-9365-d858" type="max"/>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5a3-1633-8e2b-1240" type="min"/>
+        <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea9d-9b95-9365-d858" type="max"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5a3-1633-8e2b-1240" type="min"/>
       </constraints>
       <profiles>
         <profile id="ec6b-347b-e315-75e1" name="Pirate Captain" publicationId="5766-7751-d146-0800" page="91" hidden="false" typeId="436f6d6d616e64657223232344415441232323" typeName="Commander">
           <modifiers>
             <modifier type="increment" field="52652d726f6c6c7323232344415441232323" value="1">
               <conditions>
-                <condition field="selections" scope="935e-991e-f1df-8706" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cf8c-8b7b-bcec-1598" type="equalTo"/>
+                <condition field="selections" scope="935e-991e-f1df-8706" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cf8c-8b7b-bcec-1598" type="equalTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="52652d726f6c6c7323232344415441232323" value="2">
               <conditions>
-                <condition field="selections" scope="935e-991e-f1df-8706" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="baef-123a-2721-a814" type="equalTo"/>
+                <condition field="selections" scope="935e-991e-f1df-8706" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="baef-123a-2721-a814" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -4889,121 +4899,121 @@ When rolling on the Catastrophic Damage table also add +2 tothe dice roll. The m
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="48d6-e78f-fa75-de9c" name="New CategoryLink" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="true"/>
+        <categoryLink id="48d6-e78f-fa75-de9c" name="Fleet Commander" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="8657-f477-a999-85e2" name="Extra Re-rolls" hidden="false" collective="false" import="true" defaultSelectionEntryId="dfdf-c8f3-5c6f-5113">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb8d-f6fa-5355-33e1" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2af9-9632-216e-204e" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb8d-f6fa-5355-33e1" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2af9-9632-216e-204e" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="cf8c-8b7b-bcec-1598" name="1 Extra Re-roll" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d3b-4ac4-7237-3cae" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d3b-4ac4-7237-3cae" type="max"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="points" value="25.0"/>
+                <cost name="pts" typeId="points" value="25"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="baef-123a-2721-a814" name="2 Extra Re-rolls" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b745-e1dc-a217-c6c6" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b745-e1dc-a217-c6c6" type="max"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="points" value="50.0"/>
+                <cost name="pts" typeId="points" value="50"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dfdf-c8f3-5c6f-5113" name="None" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ab8-d046-e6ea-ed4c" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ab8-d046-e6ea-ed4c" type="max"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="pts" typeId="points" value="50.0"/>
+        <cost name="pts" typeId="points" value="50"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="143e-a289-a41b-d106" name="Arbites Punisher Class Strike Cruiser" hidden="true" collective="false" import="true" type="model">
       <modifiers>
-        <modifier type="increment" field="62f9-6dbb-21a0-b03c" value="1.0">
+        <modifier type="increment" field="62f9-6dbb-21a0-b03c" value="1">
           <repeats>
-            <repeat field="points" scope="force" value="1000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" repeats="1" roundUp="false"/>
+            <repeat field="points" scope="force" value="1000" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" repeats="1" roundUp="false"/>
           </repeats>
           <conditions>
-            <condition field="points" scope="force" value="999.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="greaterThan"/>
+            <condition field="points" scope="force" value="999" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="greaterThan"/>
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="62f9-6dbb-21a0-b03c" type="max"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="62f9-6dbb-21a0-b03c" type="max"/>
       </constraints>
       <profiles>
         <profile id="ea58-99f7-cabb-b089" name="Arbites Punisher Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">6</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">25cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">6</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">25cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">90°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">6+Front/5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">2</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">2</characteristic>
           </characteristics>
         </profile>
         <profile id="28f7-8b09-c285-7083" name="Dorsal Bombardment Cannon" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
         <profile id="a85f-8f47-3b84-9572" name="Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="b38c-6690-a11a-f1ec" name="Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="fe4c-0169-3172-b885" name="Port Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Eagles: 30m</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1 Squadron</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
         <profile id="549e-ab35-02b2-9a5b" name="Starboard Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Eagles: 30m</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1 Squadron</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
         <profile id="a8b3-9b31-bd84-1752" name="Prow Torpedoes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6 (one salvo of Melta Torpedoes)</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -5015,14 +5025,14 @@ When rolling on the Catastrophic Damage table also add +2 tothe dice roll. The m
         <infoLink id="d3e6-463c-6bf9-071a" name="Torpedoes" hidden="false" targetId="8103-25d2-5412-2542" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="2e04-b0d7-2694-f1c3" name="New CategoryLink" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
+        <categoryLink id="2e04-b0d7-2694-f1c3" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
         <categoryLink id="0fe5-777c-ef0b-0653" name="CV" hidden="false" targetId="e0c6-bde4-7055-1e6e" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="31e6-8351-3cd8-9b2a" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="180.0"/>
+        <cost name="pts" typeId="points" value="180"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="eee2-1c58-2d67-dafe" name="Hawking Class Exploration Cruiser" hidden="true" collective="false" import="true" type="model">
@@ -5031,60 +5041,60 @@ When rolling on the Catastrophic Damage table also add +2 tothe dice roll. The m
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="primary-catalogue" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5fb-d016-8c2c-7046" type="max"/>
+        <constraint field="selections" scope="primary-catalogue" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5fb-d016-8c2c-7046" type="max"/>
       </constraints>
       <profiles>
         <profile id="fb4c-d714-d47e-395b" name="HawkingProfile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">6</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">25cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">6</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">25cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">90°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">2</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">2</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">2</characteristic>
           </characteristics>
         </profile>
         <profile id="2023-460b-2f4e-f71a" name="Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="45da-9188-5249-71c7" name="Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="88bd-e658-7e54-0de8" name="Prow Torpedoes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
           </characteristics>
         </profile>
         <profile id="1528-e27d-17dd-04c2" name="Port Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Furies: 30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
         <profile id="1adc-28f5-57e3-a7cd" name="Starboard Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Furies: 30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -5096,13 +5106,13 @@ When rolling on the Catastrophic Damage table also add +2 tothe dice roll. The m
         <infoLink id="1e93-8ba1-fa77-5dbf" name="Improved Thrusters" hidden="false" targetId="7040-2596-65fe-10e7" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="b82f-dd93-a9ea-be0f" name="New CategoryLink" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
+        <categoryLink id="b82f-dd93-a9ea-be0f" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
         <categoryLink id="7035-a101-a1fd-53b0" name="CV" hidden="false" targetId="e0c6-bde4-7055-1e6e" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="042d-36bf-67fb-9e59" name="Captain Maimillian Lysander" hidden="false" collective="false" import="true" type="unit">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98f7-abe9-94a3-1f4b" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98f7-abe9-94a3-1f4b" type="max"/>
           </constraints>
           <profiles>
             <profile id="1360-5a5e-6700-3b6f" name="Captain Maimillian Lysander" hidden="false" typeId="436f6d6d616e64657223232344415441232323" typeName="Commander">
@@ -5114,10 +5124,10 @@ When rolling on the Catastrophic Damage table also add +2 tothe dice roll. The m
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink id="7af9-4398-c0e3-f8d4" name="Fleet Commanders" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="false"/>
+            <categoryLink id="7af9-4398-c0e3-f8d4" name="Fleet Commander" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="false"/>
           </categoryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="75.0"/>
+            <cost name="pts" typeId="points" value="75"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -5125,7 +5135,7 @@ When rolling on the Catastrophic Damage table also add +2 tothe dice roll. The m
         <entryLink id="9bfc-0824-3d09-adc8" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="245.0"/>
+        <cost name="pts" typeId="points" value="245"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3d24-ee57-c00d-4e1a" name="Grey Knights Strike Cruiser" page="0" hidden="true" collective="false" import="true" type="model">
@@ -5134,46 +5144,46 @@ When rolling on the Catastrophic Damage table also add +2 tothe dice roll. The m
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7f18-5e2a-5067-46dd" type="max"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7f18-5e2a-5067-46dd" type="max"/>
       </constraints>
       <profiles>
         <profile id="2720-8da6-34a4-654f" name="Grey Knights Strike Cruiser Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">6</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">25cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">6</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">25cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">90°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">2</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">6+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">2</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">2</characteristic>
           </characteristics>
         </profile>
         <profile id="b02c-8f38-69b0-bfd1" name="Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="7797-4995-427c-ae1d" name="Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="7e6f-fb2a-449a-6572" name="Dorsal Bombardment Cannon" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -5181,43 +5191,43 @@ When rolling on the Catastrophic Damage table also add +2 tothe dice roll. The m
         <infoLink id="a2fc-bf7c-d7ab-914f" name="Improved Thrusters" hidden="false" targetId="7040-2596-65fe-10e7" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="5b82-79de-7336-16de" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
+        <categoryLink id="5b82-79de-7336-16de" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
         <categoryLink id="ef59-c406-5b0d-dabd" name="CV" hidden="false" targetId="e0c6-bde4-7055-1e6e" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="32b1-57ac-e93a-0546" name="Prow Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="59c0-3e33-8b7e-743e">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10f9-a231-6321-1f14" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1190-ca5a-6e0f-1775" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10f9-a231-6321-1f14" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1190-ca5a-6e0f-1775" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="59c0-3e33-8b7e-743e" name="Prow Launch Bays" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd9b-3ba7-3b6a-4fb2" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd9b-3ba7-3b6a-4fb2" type="max"/>
               </constraints>
               <profiles>
                 <profile id="c2c1-876a-bcee-5bb1" name="Prow Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Thunderhawks: 20cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9b33-e8f6-8e81-fccc" name="Prow Torpedoes" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="181a-8677-0284-0296" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="181a-8677-0284-0296" type="max"/>
               </constraints>
               <profiles>
                 <profile id="448d-d788-1630-f28b" name="Prow Torpedoes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -5225,24 +5235,24 @@ When rolling on the Catastrophic Damage table also add +2 tothe dice roll. The m
                 <infoLink id="9843-5b0b-53fb-7710" name="Torpedoes" hidden="false" targetId="8103-25d2-5412-2542" type="rule"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="09fe-01f1-440d-3f01" name="Prow Bombardment Cannon" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="703f-9c13-56d6-0f90" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="703f-9c13-56d6-0f90" type="max"/>
               </constraints>
               <profiles>
                 <profile id="f577-132f-47c4-aa6c" name="Dorsal Bombardment Cannon" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">5</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -5252,7 +5262,7 @@ When rolling on the Catastrophic Damage table also add +2 tothe dice roll. The m
         <entryLink id="e125-c508-6cff-9c2c" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="270.0"/>
+        <cost name="pts" typeId="points" value="270"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="93bf-f8b6-da01-16c3" name="Inquisition Blackship" page="0" hidden="true" collective="false" import="true" type="model">
@@ -5261,53 +5271,53 @@ When rolling on the Catastrophic Damage table also add +2 tothe dice roll. The m
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7b1c-7f7a-49e3-b3c4" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7b1c-7f7a-49e3-b3c4" type="max"/>
       </constraints>
       <profiles>
         <profile id="b152-e3eb-3b12-ca34" name="Blackship Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Battleship</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">12</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Battleship</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">12</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">5</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">6+Front/5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">5</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">5</characteristic>
           </characteristics>
         </profile>
         <profile id="1922-dab9-63b5-2b0f" name="Dorsal Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
         <profile id="7d5d-f11d-2619-963c" name="Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">10</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="7fbd-0e61-3d77-c22f" name="Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">10</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="6ee6-633a-d4b3-b938" name="Prow Torpedoes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
           </characteristics>
         </profile>
         <profile id="2a2c-778d-7dd4-c550" name="Special Rules" hidden="false" typeId="5a49-6569-78e9-a35c" typeName="Special Rule">
@@ -5331,15 +5341,15 @@ When rolling on the Catastrophic Damage table also add +2 tothe dice roll. The m
         <infoLink id="da3a-21d7-9598-c797" name="Torpedoes" hidden="false" targetId="8103-25d2-5412-2542" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="2ee7-dded-143c-30b4" hidden="false" targetId="5370656369616c23232344415441232323" primary="false"/>
-        <categoryLink id="f3c3-0cf0-1c4a-a4a1" name="Battleships" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true"/>
+        <categoryLink id="2ee7-dded-143c-30b4" hidden="false" targetId="5370656369616c23232344415441232323" primary="false" name="Special"/>
+        <categoryLink id="f3c3-0cf0-1c4a-a4a1" name="Battleship" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="dacf-6aa6-0243-b130" name="Power Ram" hidden="false" collective="false" import="true" targetId="9818-379a-5217-d9e9" type="selectionEntry"/>
         <entryLink id="6e9f-0312-f7fa-4d2c" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="300.0"/>
+        <cost name="pts" typeId="points" value="300"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c7ec-b896-8e19-d1d8" name="Inquisitorial Cruiser" page="0" hidden="true" collective="false" import="true" type="model">
@@ -5348,105 +5358,105 @@ When rolling on the Catastrophic Damage table also add +2 tothe dice roll. The m
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9e51-0032-a950-3b54" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9e51-0032-a950-3b54" type="max"/>
       </constraints>
       <profiles>
         <profile id="f935-c5bb-d2c9-3b75" name="Inquisitorial Cruiser profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">8</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">25cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">8</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">25cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">2</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">6+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">2</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">2</characteristic>
           </characteristics>
         </profile>
         <profile id="f9e5-3560-743f-716b" name="Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">8</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="fc59-9071-2b69-1733" name="Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">8</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="fc77-b19f-7c3e-3ff4" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
+        <categoryLink id="fc77-b19f-7c3e-3ff4" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
         <categoryLink id="b70e-8bd2-aefd-f279" name="CV" hidden="false" targetId="e0c6-bde4-7055-1e6e" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="6c1c-25cc-a5d2-603e" name="Dorsal Weapon Option" hidden="false" collective="false" import="true" defaultSelectionEntryId="b393-c75b-ab95-dfcf">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e7e-f008-12d9-ebb3" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6019-3772-982a-d2c6" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e7e-f008-12d9-ebb3" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6019-3772-982a-d2c6" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="b393-c75b-ab95-dfcf" name="Bombardment Cannon" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e269-3639-8341-28ba" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e269-3639-8341-28ba" type="max"/>
               </constraints>
               <profiles>
                 <profile id="83c3-c24f-9c4f-d9b6" name="Dorsal Bombardment Cannon" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="de1e-3d51-cfe1-e1ae" name="Dorsal Lances" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a818-ae6e-987c-b586" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a818-ae6e-987c-b586" type="max"/>
               </constraints>
               <profiles>
                 <profile id="f981-87ae-904a-f13f" name="Dorsal Lances" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="c27e-d081-d835-427d" name="Prow Weapons Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="1b5c-b454-0033-55f5">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6220-5242-b96b-1f09" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93a3-9e86-7baa-775a" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6220-5242-b96b-1f09" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93a3-9e86-7baa-775a" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="1b5c-b454-0033-55f5" name="Prow Launch Bays" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7943-321e-5508-b8a9" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7943-321e-5508-b8a9" type="max"/>
               </constraints>
               <profiles>
                 <profile id="1295-7889-68e8-116d" name="Prow Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Thunderhawks: 20cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -5454,19 +5464,19 @@ When rolling on the Catastrophic Damage table also add +2 tothe dice roll. The m
                 <infoLink id="1aa1-6965-19ee-7331" name="Thunderhawk Gunship" hidden="false" targetId="843f-ef90-8376-4f0b" type="profile"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="60e6-39a8-4201-46aa" name="Prow Torpedoes" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="88d9-9381-e69d-ae38" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="88d9-9381-e69d-ae38" type="max"/>
               </constraints>
               <profiles>
                 <profile id="8b3a-e580-9375-9b22" name="Prow Torpedoes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="9c39-df4c-2c90-e20e" name="Prow Torpedoes" hidden="false" typeId="5a49-6569-78e9-a35c" typeName="Special Rule">
@@ -5479,7 +5489,7 @@ When rolling on the Catastrophic Damage table also add +2 tothe dice roll. The m
                 <infoLink id="f951-ca74-b708-a0dc" name="Torpedoes" hidden="false" targetId="8103-25d2-5412-2542" type="rule"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -5489,7 +5499,7 @@ When rolling on the Catastrophic Damage table also add +2 tothe dice roll. The m
         <entryLink id="9d42-a587-f601-0eb5" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="270.0"/>
+        <cost name="pts" typeId="points" value="270"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2a40-84fd-e18d-298b" name="Armed Cargo Vessel" hidden="true" collective="false" import="true" type="model">
@@ -5498,7 +5508,7 @@ When rolling on the Catastrophic Damage table also add +2 tothe dice roll. The m
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -5507,31 +5517,31 @@ When rolling on the Catastrophic Damage table also add +2 tothe dice roll. The m
       <profiles>
         <profile id="f5a3-4488-d87a-4117" name="Armed Cargo Vessel Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Escort</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">1</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">25cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Escort</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">1</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">25cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">1</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">1</characteristic>
           </characteristics>
         </profile>
         <profile id="8cdb-2a57-87ce-c6be" name="Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">left/Front/Right</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="3a0b-7980-5ef7-bc9e" name="New CategoryLink" hidden="false" targetId="4573636f72747323232344415441232323" primary="true"/>
+        <categoryLink id="3a0b-7980-5ef7-bc9e" name="Escort" hidden="false" targetId="4573636f72747323232344415441232323" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="9f56-afe8-6bfc-37fa" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="25.0"/>
+        <cost name="pts" typeId="points" value="25"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d7fb-7ac7-538a-0a86" name="Siluria Class Light Cruiser" publicationId="5766-7751-d146-0800" page="43" hidden="true" collective="false" import="true" type="model">
@@ -5540,8 +5550,8 @@ When rolling on the Catastrophic Damage table also add +2 tothe dice roll. The m
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -5550,41 +5560,41 @@ When rolling on the Catastrophic Damage table also add +2 tothe dice roll. The m
       <profiles>
         <profile id="0990-e6d4-73cc-b1a4" name="Siluria Profile" publicationId="5766-7751-d146-0800" page="43" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <modifiers>
-            <modifier type="increment" field="5475727265747323232344415441232323" value="1">
+            <modifier type="increment" field="5.475727265747323e+33" value="1">
               <conditions>
-                <condition field="selections" scope="d7fb-7ac7-538a-0a86" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8025-e5ea-9b7b-7f59" type="atLeast"/>
+                <condition field="selections" scope="d7fb-7ac7-538a-0a86" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8025-e5ea-9b7b-7f59" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">6</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">25cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">6</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">25cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">90°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">1</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">1</characteristic>
           </characteristics>
         </profile>
         <profile id="0b88-d957-5ca1-595d" name="Prow Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
         <profile id="e440-a49f-3ff9-090b" name="Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="140d-c262-ca90-1555" name="Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -5592,7 +5602,7 @@ When rolling on the Catastrophic Damage table also add +2 tothe dice roll. The m
         <infoLink id="2abf-bfc2-9175-dc1c" name="Improved Thrusters" hidden="false" targetId="7040-2596-65fe-10e7" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="b0fc-d68a-ec68-4ec3" name="New CategoryLink" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
+        <categoryLink id="b0fc-d68a-ec68-4ec3" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
         <categoryLink id="d198-a0c6-057b-c435" name="CV" hidden="false" targetId="e0c6-bde4-7055-1e6e" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -5600,19 +5610,19 @@ When rolling on the Catastrophic Damage table also add +2 tothe dice roll. The m
         <entryLink id="1271-4ec6-9315-1512" name="Bakka Turret" hidden="false" collective="false" import="true" targetId="8025-e5ea-9b7b-7f59" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="100.0"/>
+        <cost name="pts" typeId="points" value="100"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f990-8916-3a92-c5bc" name="Veteran Captain" hidden="true" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="force" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39be-bda6-60aa-056c" type="max"/>
+        <constraint field="selections" scope="force" value="5" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39be-bda6-60aa-056c" type="max"/>
       </constraints>
       <profiles>
         <profile id="d93b-9a2c-47cc-d2fc" name="Veteran Captain" publicationId="1bc8-5968-21c3-0f27" page="29" hidden="false" typeId="436f6d6d616e64657223232344415441232323" typeName="Commander">
@@ -5631,13 +5641,13 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="0f4c-c32a-2677-2f46" name="New CategoryLink" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="true"/>
+        <categoryLink id="0f4c-c32a-2677-2f46" name="Fleet Commander" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="9466-3d3a-4f81-7c01" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="50.0"/>
+        <cost name="pts" typeId="points" value="50"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="aa60-a99e-eda0-d327" name="Master of The Fleet" publicationId="1bc8-5968-21c3-0f27" page="30" hidden="true" collective="false" import="true" type="upgrade">
@@ -5646,24 +5656,24 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92ed-ae38-696a-33a7" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92ed-ae38-696a-33a7" type="max"/>
       </constraints>
       <profiles>
         <profile id="b562-82c9-dc07-bd72" name="Master of The Fleet" hidden="false" typeId="436f6d6d616e64657223232344415441232323" typeName="Commander">
           <modifiers>
             <modifier type="increment" field="52652d726f6c6c7323232344415441232323" value="1">
               <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="90c4-eaa2-e8ea-59a2" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="90c4-eaa2-e8ea-59a2" repeats="1" roundUp="false"/>
               </repeats>
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="90c4-eaa2-e8ea-59a2" type="instanceOf"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="90c4-eaa2-e8ea-59a2" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -5675,12 +5685,12 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="1114-c96c-f5ab-f85d" name="New CategoryLink" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="true"/>
+        <categoryLink id="1114-c96c-f5ab-f85d" name="Fleet Commander" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="d986-ad67-b106-7b39" name="Terminator Boarding Party" publicationId="1bc8-5968-21c3-0f27" page="30" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ed0-e9e6-485a-0c79" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ed0-e9e6-485a-0c79" type="max"/>
           </constraints>
           <profiles>
             <profile id="243b-4ef0-7d09-aa90" name="Terminator Boarding Party" hidden="false" typeId="5a49-6569-78e9-a35c" typeName="Special Rule">
@@ -5690,20 +5700,20 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="50.0"/>
+            <cost name="pts" typeId="points" value="50"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="90c4-eaa2-e8ea-59a2" name="Re-rolls" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d4d-4932-6624-7734" type="max"/>
+            <constraint field="selections" scope="parent" value="3" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d4d-4932-6624-7734" type="max"/>
           </constraints>
           <costs>
-            <cost name="pts" typeId="points" value="25.0"/>
+            <cost name="pts" typeId="points" value="25"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
-        <cost name="pts" typeId="points" value="50.0"/>
+        <cost name="pts" typeId="points" value="50"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5e2e-1b44-cdc5-9917" name="Invincible Class Fast Battleship" hidden="true" collective="false" import="true" type="model">
@@ -5712,53 +5722,53 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="primary-catalogue" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb42-eafb-b55d-42bc" type="max"/>
+        <constraint field="selections" scope="primary-catalogue" value="10" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb42-eafb-b55d-42bc" type="max"/>
       </constraints>
       <profiles>
         <profile id="9664-2fd7-18ad-de6d" name="Invincible Class Fast Battleship" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Battleship</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">8</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">25cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Battleship</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">8</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">25cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">2</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+/6+Front</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">4</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">4</characteristic>
           </characteristics>
         </profile>
         <profile id="b1a7-a7de-41f2-bed0" name="Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">12</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="18f2-2d29-09b9-41d1" name="Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">12</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="f452-9510-dab5-0a1b" name="Dorsal Lance" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
         <profile id="0c57-b4d6-0f33-4230" name="Prow Torpedoes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
           </characteristics>
         </profile>
         <profile id="192d-f4d9-1e8c-89a9" name="Invincible Class Fast Battleship" hidden="false" typeId="5a49-6569-78e9-a35c" typeName="Special Rule">
@@ -5771,29 +5781,29 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
         <infoLink id="811f-a547-4693-ddb3" name="Torpedoes" hidden="false" targetId="8103-25d2-5412-2542" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="4bfc-348d-74b0-dc26" name="New CategoryLink" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true"/>
+        <categoryLink id="4bfc-348d-74b0-dc26" name="Battleship" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="3e6e-d5a4-5590-5b58" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="290.0"/>
+        <cost name="pts" typeId="points" value="290"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f099-70b7-133c-557c" name="Endeavour Class Light Cruiser" publicationId="5766-7751-d146-0800" page="42" hidden="true" collective="false" import="true" type="model">
       <comment>different from imperial endeavor see armada for imperial version and 2010 for points adjust</comment>
       <modifiers>
-        <modifier type="increment" field="points" value="35.0">
+        <modifier type="increment" field="points" value="35">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -5804,56 +5814,56 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
           <modifiers>
             <modifier type="set" field="5475726e7323232344415441232323" value="45°">
               <conditions>
-                <condition field="selections" scope="f099-70b7-133c-557c" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="ab9e-0191-840c-ccdf" type="equalTo"/>
+                <condition field="selections" scope="f099-70b7-133c-557c" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="ab9e-0191-840c-ccdf" type="equalTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="41726d6f757223232344415441232323" value="6+">
               <conditions>
-                <condition field="selections" scope="f099-70b7-133c-557c" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="ab9e-0191-840c-ccdf" type="equalTo"/>
+                <condition field="selections" scope="f099-70b7-133c-557c" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="ab9e-0191-840c-ccdf" type="equalTo"/>
               </conditions>
             </modifier>
-            <modifier type="set" field="5475727265747323232344415441232323" value="4">
+            <modifier type="set" field="5.475727265747323e+33" value="4">
               <conditions>
-                <condition field="selections" scope="f099-70b7-133c-557c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="032c-e71b-b86c-acdf" type="equalTo"/>
+                <condition field="selections" scope="f099-70b7-133c-557c" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="032c-e71b-b86c-acdf" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">6</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">6</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">90°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">3</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">3</characteristic>
           </characteristics>
         </profile>
         <profile id="f313-15dc-4c9f-90d4" name="Prow Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
         <profile id="0e14-3dcb-5f73-c242" name="Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="eed1-5599-6155-1ed7" name="Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="a9a3-5eb6-f5ab-89c5" name="Prow Torpedoes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -5862,13 +5872,13 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
         <infoLink id="7cae-ccb1-be49-a3a4" name="Torpedoes" hidden="false" targetId="8103-25d2-5412-2542" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="aad8-0226-becf-c44a" name="New CategoryLink" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
+        <categoryLink id="aad8-0226-becf-c44a" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
         <categoryLink id="1939-0416-a2c3-e208" name="CV" hidden="false" targetId="e0c6-bde4-7055-1e6e" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="2ba4-7b53-cbba-5658" name="Power Ram" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c505-c417-021a-e5bd" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c505-c417-021a-e5bd" type="max"/>
           </constraints>
           <profiles>
             <profile id="402b-bf1a-ba5d-58b1" name="Power Ram" publicationId="11f0-17d1-e4d2-1018" page="115" hidden="false" typeId="5a49-6569-78e9-a35c" typeName="Special Rule">
@@ -5878,25 +5888,25 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
+            <cost name="pts" typeId="points" value="5"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="e68f-9fb4-5a70-0a3f" name="Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="dc75-4c9e-7f3a-713f">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89a6-fc4b-21fc-2cd2" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3777-7b50-4784-46ff" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89a6-fc4b-21fc-2cd2" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3777-7b50-4784-46ff" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="ab9e-0191-840c-ccdf" name="Extra Armor" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dc75-4c9e-7f3a-713f" name="Standard" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -5907,7 +5917,7 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
               </conditions>
             </modifier>
             <modifier type="decrement" field="points" value="10"/>
@@ -5918,33 +5928,33 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a941-440d-1aba-9778" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a941-440d-1aba-9778" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="115.0"/>
+        <cost name="pts" typeId="points" value="115"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="81d5-a297-28d7-3036" name="Endurance Class Light Cruiser" publicationId="5766-7751-d146-0800" page="42" hidden="true" collective="false" import="true" type="model">
       <comment>different from imperial endurance</comment>
       <modifiers>
-        <modifier type="increment" field="points" value="35.0">
+        <modifier type="increment" field="points" value="35">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -5955,56 +5965,56 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
           <modifiers>
             <modifier type="set" field="5475726e7323232344415441232323" value="45°">
               <conditions>
-                <condition field="selections" scope="81d5-a297-28d7-3036" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="0c09-af7b-6be5-450f" type="equalTo"/>
+                <condition field="selections" scope="81d5-a297-28d7-3036" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="0c09-af7b-6be5-450f" type="equalTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="41726d6f757223232344415441232323" value="6+">
               <conditions>
-                <condition field="selections" scope="81d5-a297-28d7-3036" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="0c09-af7b-6be5-450f" type="equalTo"/>
+                <condition field="selections" scope="81d5-a297-28d7-3036" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="0c09-af7b-6be5-450f" type="equalTo"/>
               </conditions>
             </modifier>
-            <modifier type="set" field="5475727265747323232344415441232323" value="4">
+            <modifier type="set" field="5.475727265747323e+33" value="4">
               <conditions>
-                <condition field="selections" scope="81d5-a297-28d7-3036" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="032c-e71b-b86c-acdf" type="equalTo"/>
+                <condition field="selections" scope="81d5-a297-28d7-3036" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="032c-e71b-b86c-acdf" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">6</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">6</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">90°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">3</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">3</characteristic>
           </characteristics>
         </profile>
         <profile id="d202-f884-1219-3b75" name="Prow Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
         <profile id="68c7-ab7c-05a3-bc3a" name="Port Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="66c3-2cb9-20d2-78c5" name="Starboard Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="d174-3921-a3ef-f2a3" name="Prow Torpedoes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -6013,13 +6023,13 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
         <infoLink id="f5ba-fda4-c65a-ee06" name="Torpedoes" hidden="false" targetId="8103-25d2-5412-2542" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="9111-2f9e-28b4-7f01" name="New CategoryLink" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
+        <categoryLink id="9111-2f9e-28b4-7f01" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
         <categoryLink id="dcb3-5900-0d68-1b7d" name="CV" hidden="false" targetId="e0c6-bde4-7055-1e6e" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="eb35-6a28-f6a1-0962" name="Power Ram" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d65-cf03-26d5-9e70" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d65-cf03-26d5-9e70" type="max"/>
           </constraints>
           <profiles>
             <profile id="d6da-c712-2018-1b8e" name="Power Ram" publicationId="11f0-17d1-e4d2-1018" page="115" hidden="false" typeId="5a49-6569-78e9-a35c" typeName="Special Rule">
@@ -6029,25 +6039,25 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
+            <cost name="pts" typeId="points" value="5"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="1f39-139e-94d2-e772" name="Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="7cf6-c708-0913-484e">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="464e-0f7b-e69f-ee8a" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3312-5b86-a030-6a47" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="464e-0f7b-e69f-ee8a" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3312-5b86-a030-6a47" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="0c09-af7b-6be5-450f" name="Extra Armor" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7cf6-c708-0913-484e" name="Standard" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -6058,7 +6068,7 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
               </conditions>
             </modifier>
             <modifier type="decrement" field="points" value="10"/>
@@ -6069,18 +6079,57 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="939d-a749-fb24-3657" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="939d-a749-fb24-3657" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="115.0"/>
+        <cost name="pts" typeId="points" value="115"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Lord Admiral Rath" hidden="true" id="4282-4e4d-6688-ba0c">
+      <categoryLinks>
+        <categoryLink targetId="466c65657420436f6d6d616e6465727323232344415441232323" id="3be9-99f0-dc6c-f1a1" primary="true" name="Fleet Commander"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="200"/>
+      </costs>
+      <constraints>
+        <constraint type="max" value="0" field="selections" scope="parent" shared="true" id="4e35-f97f-5711-36e0"/>
+      </constraints>
+      <rules>
+        <rule name="Lord Zaccarius Rath Ldr 10" id="32e9-def3-fd35-9542" hidden="false" publicationId="5766-7751-d146-0800" page="36">
+          <description>Lord Admiral Rath is Ld-10 and comes with two rerolls as part of his point cost. His crew is honored and inspired by the great man‟s presence and will fight with great courage and pride; they add +1 to their roll when defending against boarding actions. Respect for him extends to the forge world of Bakka itself, and his flagship receives one ship refit and weapon refit (rolled randomly) as part of his point cost. In a campaign, a ship so refitted must remain his flagship unless it is destroyed.</description>
+        </rule>
+      </rules>
+      <modifiers>
+        <modifier type="set" value="false" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition type="instanceOf" value="0" field="selections" scope="force" childId="7529-da04-0225-31de" shared="true" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                <condition type="instanceOf" value="0" field="selections" scope="force" childId="e874-e62b-1c36-7aec" shared="true" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="increment" value="1" field="4e35-f97f-5711-36e0">
+          <conditions>
+            <condition type="greaterThan" value="1499" field="points" scope="roster" childId="any" shared="true" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+            <condition type="atLeast" value="1" field="selections" scope="parent" childId="any" shared="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="decrement" value="1" field="4e35-f97f-5711-36e0">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="466c65657420436f6d6d616e6465727323232344415441232323" childId="e670be5a-3aad-4eba-9e5e-2b79130c13b6" shared="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
     </selectionEntry>
   </selectionEntries>
   <entryLinks>
@@ -6090,16 +6139,16 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="eca7-5d3d-62c2-8685" name="New CategoryLink" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="true"/>
+        <categoryLink id="eca7-5d3d-62c2-8685" name="Grand Cruiser" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="bec7-56fa-6748-7c2d" name="Apocalypse Class Battleship" hidden="true" collective="false" import="true" targetId="c133-b14e-e57c-cb12" type="selectionEntry">
@@ -6108,10 +6157,10 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -6124,10 +6173,10 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -6140,9 +6189,9 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -6155,12 +6204,32 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed8-4a6a-2f2b-833d" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed8-4a6a-2f2b-833d" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" value="false" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="force" childId="e874-e62b-1c36-7aec" shared="true" includeChildSelections="true"/>
+                <condition type="atLeast" value="3" field="selections" scope="4361706974616c20536869707323232344415441232323" childId="any" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" value="false" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="force" childId="e874-e62b-1c36-7aec" shared="true" includeChildSelections="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="466c65657420436f6d6d616e6465727323232344415441232323" childId="4282-4e4d-6688-ba0c" shared="true" includeChildSelections="true" includeChildForces="true"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -6173,9 +6242,9 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -6188,11 +6257,11 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed8-4a6a-2f2b-833d" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed8-4a6a-2f2b-833d" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -6205,9 +6274,9 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -6220,10 +6289,10 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed8-4a6a-2f2b-833d" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed8-4a6a-2f2b-833d" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -6236,12 +6305,12 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed8-4a6a-2f2b-833d" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed8-4a6a-2f2b-833d" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -6254,8 +6323,8 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -6268,7 +6337,7 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -6279,21 +6348,21 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
       <modifiers>
         <modifier type="decrement" field="5ea7-74e8-868e-3ccb" value="2">
           <conditions>
-            <condition field="points" scope="force" value="2000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="lessThan"/>
+            <condition field="points" scope="force" value="2000" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="lessThan"/>
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="primary-catalogue" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ea7-74e8-868e-3ccb" type="max"/>
+        <constraint field="selections" scope="primary-catalogue" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ea7-74e8-868e-3ccb" type="max"/>
       </constraints>
     </entryLink>
     <entryLink id="ea05-9f08-f7bb-db43" name="Invincible Class Fast Battleship" hidden="true" collective="false" import="true" targetId="35ea-70f6-8ccc-e4e0" type="selectionEntry">
@@ -6302,7 +6371,7 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -6315,14 +6384,14 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="primary-catalogue" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c5b-68df-1a5f-09ef" type="max"/>
+        <constraint field="selections" scope="primary-catalogue" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c5b-68df-1a5f-09ef" type="max"/>
       </constraints>
     </entryLink>
     <entryLink id="a2c3-6cce-bf90-3cdb" name="Jovian Class Battlecruiser" hidden="true" collective="false" import="true" targetId="481c-4670-972c-f69d" type="selectionEntry">
@@ -6331,9 +6400,9 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -6346,7 +6415,7 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -6359,7 +6428,7 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -6372,7 +6441,7 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -6385,7 +6454,7 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -6398,8 +6467,8 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -6412,7 +6481,7 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -6429,8 +6498,8 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -6441,7 +6510,7 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
           <modifiers>
             <modifier type="append" field="52616e67652f537065656423232344415441232323" value="Shark Assault Boats: 30cm">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0775-2b9d-28d5-c715" type="instanceOf"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0775-2b9d-28d5-c715" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -6449,14 +6518,14 @@ A Veteran Captain gets one re-roll which is included in their points cost and ca
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Fighters: 30cm
 Bombers: 20cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
         <profile id="24ea-d38d-525e-08ce" name="Starboard Lanch Bay" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <modifiers>
             <modifier type="append" field="52616e67652f537065656423232344415441232323" value="Shark Assault Boats: 30cm">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0775-2b9d-28d5-c715" type="instanceOf"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0775-2b9d-28d5-c715" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -6464,7 +6533,7 @@ Bombers: 20cm</characteristic>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Fighters: 30cm
 Bombers: 20cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -6473,12 +6542,12 @@ Bombers: 20cm</characteristic>
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b27-bc9b-67c8-db1c" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b27-bc9b-67c8-db1c" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="00fb-7969-dba8-ca5d" name="Imperial Ordnance" hidden="false" collective="false" import="true" targetId="2da3-6f87-b676-1862" type="selectionEntryGroup"/>
@@ -6490,7 +6559,7 @@ Bombers: 20cm</characteristic>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -6499,22 +6568,22 @@ Bombers: 20cm</characteristic>
       <profiles>
         <profile id="ef0c-7d8f-87ab-58ff" name="Retaliator Port Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
-            <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Furies: 30cm Starhawks: 20cm </characteristic>
+            <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Furies: 30cm Starhawks: 20cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2 Squadrons</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
         <profile id="adf9-7f54-a7ca-0c18" name="Retaliator Starboard Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
-            <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Furies: 30cm Starhawks: 20cm </characteristic>
+            <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Furies: 30cm Starhawks: 20cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2 Squadrons</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="7cda-d4cc-81fd-0b90" name="New CategoryLink" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="true"/>
-        <categoryLink id="95d1-b42a-791a-07ae" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
+        <categoryLink id="7cda-d4cc-81fd-0b90" name="Grand Cruiser" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="true"/>
+        <categoryLink id="95d1-b42a-791a-07ae" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="961d-dd58-6aca-cf43" name="Imperial Ordnance" hidden="false" collective="false" import="true" targetId="2da3-6f87-b676-1862" type="selectionEntryGroup"/>
@@ -6526,14 +6595,14 @@ Bombers: 20cm</characteristic>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="set-primary" field="category" value="9624-17a2-bfd7-6420">
           <conditions>
-            <condition field="selections" scope="primary-catalogue" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cdc1-e60c-6456-c57a" type="instanceOf"/>
+            <condition field="selections" scope="primary-catalogue" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cdc1-e60c-6456-c57a" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -6542,14 +6611,14 @@ Bombers: 20cm</characteristic>
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Furies: 30cm StarHawks: 20cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3 Squadrons</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
         <profile id="a157-32ac-265d-4b2c" name="Styx Starboard Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Swiftdeaths: 30cm Doomfires: 20cm Dreadclaws: 30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3 Squadrons</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -6563,10 +6632,10 @@ Bombers: 20cm</characteristic>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -6579,10 +6648,10 @@ Bombers: 20cm</characteristic>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -6595,10 +6664,10 @@ Bombers: 20cm</characteristic>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -6611,8 +6680,8 @@ Bombers: 20cm</characteristic>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -6623,22 +6692,22 @@ Bombers: 20cm</characteristic>
       <modifiers>
         <modifier type="set" field="name" value="Rapid Strike Cobra Destroyer">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
           </conditions>
         </modifier>
-        <modifier type="set" field="points" value="35.0">
+        <modifier type="set" field="points" value="35">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cb0-5f33-c0c3-bb1b" type="max"/>
+        <constraint field="selections" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cb0-5f33-c0c3-bb1b" type="max"/>
       </constraints>
       <infoLinks>
         <infoLink id="0a5a-1462-f785-7a8e" name="Rapid Strike Vessels" hidden="false" targetId="3c73-8a2f-5cbd-932b" type="rule"/>
@@ -6646,7 +6715,7 @@ Bombers: 20cm</characteristic>
       <entryLinks>
         <entryLink id="0312-e2f0-842e-bc1f" name="Widowmaker Cobra" hidden="false" collective="false" import="true" targetId="dc88-f7ed-8352-4f11" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65c8-e3f0-0dee-522a" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65c8-e3f0-0dee-522a" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
@@ -6657,7 +6726,7 @@ Bombers: 20cm</characteristic>
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -6700,7 +6769,7 @@ Mechanicus fleet commanders gain refits as they increase in renown (see the AM p
   <sharedSelectionEntries>
     <selectionEntry id="98bf-3be8-c076-97f3" name="Honour Guard" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="113f-cff4-d355-4ec5" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="113f-cff4-d355-4ec5" type="max"/>
       </constraints>
       <profiles>
         <profile id="e746-c90c-e769-a107" name="Honour Guard" hidden="false" typeId="5a49-6569-78e9-a35c" typeName="Special Rule">
@@ -6710,12 +6779,12 @@ Mechanicus fleet commanders gain refits as they increase in renown (see the AM p
         </profile>
       </profiles>
       <costs>
-        <cost name="pts" typeId="points" value="10.0"/>
+        <cost name="pts" typeId="points" value="10"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="66ac-88be-0e74-c340" name="Space Marine Crew" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee63-c4f2-5310-cf1a" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee63-c4f2-5310-cf1a" type="max"/>
       </constraints>
       <profiles>
         <profile id="521d-4f24-1db5-60e5" name="Space Marine Crew" hidden="false" typeId="5a49-6569-78e9-a35c" typeName="Special Rule">
@@ -6737,23 +6806,23 @@ In a Planetary Assault scenario, Space Marine strike cruisers and battle barges 
         </profile>
       </profiles>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0775-2b9d-28d5-c715" name="Shark Assault Boats" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bda7-c293-deb1-7821" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bda7-c293-deb1-7821" type="max"/>
       </constraints>
       <infoLinks>
         <infoLink id="cf40-f1d4-5b6b-6c1d" name="Assault Boats" hidden="false" targetId="187e-bb8f-bd53-e0eb" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name="pts" typeId="points" value="5.0"/>
+        <cost name="pts" typeId="points" value="5"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9818-379a-5217-d9e9" name="Power Ram" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="966b-ec63-e18b-fdd9" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="966b-ec63-e18b-fdd9" type="max"/>
       </constraints>
       <profiles>
         <profile id="34ae-8001-491f-b1ee" name="Power Ram" publicationId="11f0-17d1-e4d2-1018" page="115" hidden="false" typeId="5a49-6569-78e9-a35c" typeName="Special Rule">
@@ -6763,7 +6832,7 @@ In a Planetary Assault scenario, Space Marine strike cruisers and battle barges 
         </profile>
       </profiles>
       <costs>
-        <cost name="pts" typeId="points" value="5.0"/>
+        <cost name="pts" typeId="points" value="5"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c133-b14e-e57c-cb12" name="Apocalypse Class Battleship" publicationId="1bc8-5968-21c3-0f27" page="12" hidden="false" collective="false" import="true" type="unit">
@@ -6771,34 +6840,34 @@ In a Planetary Assault scenario, Space Marine strike cruisers and battle barges 
       <profiles>
         <profile id="aff3-d347-19df-54fb" name="Apocalypse Profile" publicationId="1bc8-5968-21c3-0f27" page="12" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Battleship</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">12</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">15cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Battleship</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">12</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">15cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">4</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">6+Front/5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">4</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">4</characteristic>
           </characteristics>
         </profile>
         <profile id="5075-2dd6-ca41-ecf2" name="Port Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="a6e1-c792-265b-ba7f" name="Starboard Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="dbf7-7fb4-f942-6ae8" name="Dorsal Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
         <profile id="65a7-fb7e-0872-fa2c" name="Special Lock On" publicationId="1bc8-5968-21c3-0f27" page="12" hidden="false" typeId="5a49-6569-78e9-a35c" typeName="Special Rule">
@@ -6812,14 +6881,14 @@ In a Planetary Assault scenario, Space Marine strike cruisers and battle barges 
         <infoLink id="230b-92f9-9a9c-ba16" name="Prow Nova Cannon" hidden="false" targetId="af91-33ff-94d6-44f4" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="e1ba-0b32-6356-5018" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true"/>
+        <categoryLink id="e1ba-0b32-6356-5018" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true" name="Battleship"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="0ed8-5f29-d5ee-0c81" name="Power Ram" hidden="false" collective="false" import="true" targetId="9818-379a-5217-d9e9" type="selectionEntry"/>
         <entryLink id="e724-dcfc-65d8-ff51" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="365.0"/>
+        <cost name="pts" typeId="points" value="365"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="35af-bdab-91ca-40fb" name="Armageddon Class Battlecruiser" publicationId="b161-6b4c-e770-9ab2" page="17" hidden="true" collective="false" import="true" type="unit">
@@ -6829,12 +6898,12 @@ In a Planetary Assault scenario, Space Marine strike cruisers and battle barges 
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -6843,55 +6912,55 @@ In a Planetary Assault scenario, Space Marine strike cruisers and battle barges 
       <profiles>
         <profile id="d78a-164a-843b-659c" name="Armageddon Profile" publicationId="1bc8-5968-21c3-0f27" page="17" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <modifiers>
-            <modifier type="increment" field="5475727265747323232344415441232323" value="1">
+            <modifier type="increment" field="5.475727265747323e+33" value="1">
               <conditions>
-                <condition field="selections" scope="35af-bdab-91ca-40fb" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8025-e5ea-9b7b-7f59" type="atLeast"/>
+                <condition field="selections" scope="35af-bdab-91ca-40fb" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8025-e5ea-9b7b-7f59" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">8</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">8</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">2</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">6+Front/5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">2</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">2</characteristic>
           </characteristics>
         </profile>
         <profile id="8ba3-5520-79b4-2219" name="Port Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="3414-e83d-aabf-6e46" name="Starboard Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="2888-772a-4b4e-2258" name="Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="4480-7859-b2d8-3f02" name="Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="7271-fe65-b6ae-0983" name="Dorsal Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -6899,14 +6968,14 @@ In a Planetary Assault scenario, Space Marine strike cruisers and battle barges 
         <infoLink id="c6c8-2351-81d5-4e02" name="Torpedoes" hidden="false" targetId="8103-25d2-5412-2542" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="e440-2202-3faa-8287" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
-        <categoryLink id="5b9c-2631-6f17-3b18" name="Battle Cruiser" hidden="false" targetId="b041-ef69-0039-d535" primary="true"/>
+        <categoryLink id="e440-2202-3faa-8287" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
+        <categoryLink id="5b9c-2631-6f17-3b18" name="Battlecruiser" hidden="false" targetId="b041-ef69-0039-d535" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="9223-bfc2-a565-c757" name="Prow Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="a696-026d-ca3f-77df">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="734e-2357-4fb0-f16e" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d5a-518b-57a8-976b" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="734e-2357-4fb0-f16e" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d5a-518b-57a8-976b" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="b601-1fe2-631a-0e67" name="Prow Nova Cannon" hidden="false" collective="false" import="true" type="upgrade">
@@ -6914,7 +6983,7 @@ In a Planetary Assault scenario, Space Marine strike cruisers and battle barges 
                 <infoLink id="bad9-1c35-6570-aa8c" name="Prow Nova Cannon" hidden="false" targetId="af91-33ff-94d6-44f4" type="profile"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
+                <cost name="pts" typeId="points" value="20"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a696-026d-ca3f-77df" name="Prow Torpedos" hidden="false" collective="false" import="true" type="upgrade">
@@ -6923,12 +6992,12 @@ In a Planetary Assault scenario, Space Marine strike cruisers and battle barges 
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -6939,7 +7008,7 @@ In a Planetary Assault scenario, Space Marine strike cruisers and battle barges 
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6952,42 +7021,42 @@ In a Planetary Assault scenario, Space Marine strike cruisers and battle barges 
         <entryLink id="3d9d-4239-3744-c8f3" name="Bakka Turret" hidden="false" collective="false" import="true" targetId="8025-e5ea-9b7b-7f59" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="235.0"/>
+        <cost name="pts" typeId="points" value="235"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1fda-2b76-b64f-e8d3" name="Avenger Class Grand Cruiser" publicationId="1bc8-5968-21c3-0f27" page="15" hidden="true" collective="false" import="true" type="unit">
       <modifiers>
-        <modifier type="set" field="points" value="220.0">
+        <modifier type="set" field="points" value="220">
           <comment>the bastion fleet list says 200 the profile says 220</comment>
           <conditions>
-            <condition field="selections" scope="c52d-5b11-b7cd-f654" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1fda-2b76-b64f-e8d3" type="lessThan"/>
+            <condition field="selections" scope="c52d-5b11-b7cd-f654" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1fda-2b76-b64f-e8d3" type="lessThan"/>
           </conditions>
         </modifier>
       </modifiers>
       <profiles>
         <profile id="c4a0-fa74-8e0d-2a32" name="Avenger Profile" publicationId="1bc8-5968-21c3-0f27" page="15" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Grand Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">10</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Grand Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">10</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">3</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">3</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">3</characteristic>
           </characteristics>
         </profile>
         <profile id="2a32-dbab-762e-d9a0" name="Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">16</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="8065-f03c-bfc1-7752" name="Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">16</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="76c7-ff89-2cbf-f3ec" name="Armored Prow" publicationId="5766-7751-d146-0800" page="23" hidden="false" typeId="5a49-6569-78e9-a35c" typeName="Special Rule">
@@ -6997,110 +7066,108 @@ In a Planetary Assault scenario, Space Marine strike cruisers and battle barges 
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="e387-0b39-0342-7db3" name="New CategoryLink" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="true"/>
+        <categoryLink id="e387-0b39-0342-7db3" name="Grand Cruiser" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="6190-4e6c-0586-f959" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="200.0"/>
+        <cost name="pts" typeId="points" value="200"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="fd03-5f22-b33e-38dc" name="Emperor Class Battleship" publicationId="11f0-17d1-e4d2-1018" page="106" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="increment" field="points" value="35">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
       <profiles>
         <profile id="027f-9f95-9944-cdf0" name="Emperor Profile" publicationId="11f0-17d1-e4d2-1018" page="106" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <modifiers>
-            <modifier type="increment" field="5475727265747323232344415441232323" value="1">
+            <modifier type="increment" field="5.475727265747323e+33" value="1">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Battleship</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">12</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">15cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Battleship</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">12</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">15cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">4</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">5</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">5</characteristic>
           </characteristics>
         </profile>
         <profile id="b623-d958-538d-5a14" name="Emperor Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="9391-038b-6832-5948" name="Emperor Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="dafe-4334-5e93-7e3a" name="Emperor Dorsal Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">5</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Right/Front</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Right/Front</characteristic>
           </characteristics>
         </profile>
         <profile id="e8b2-81d0-3192-dc96" name="Emperor Prow Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">5</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Right/Front</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Right/Front</characteristic>
           </characteristics>
         </profile>
         <profile id="d216-8065-09a1-5e93" name="Emperor Port Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <modifiers>
             <modifier type="append" field="52616e67652f537065656423232344415441232323" value=" Sharks: 30cm">
               <conditions>
-                <condition field="selections" scope="fd03-5f22-b33e-38dc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0775-2b9d-28d5-c715" type="atLeast"/>
+                <condition field="selections" scope="fd03-5f22-b33e-38dc" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0775-2b9d-28d5-c715" type="atLeast"/>
               </conditions>
             </modifier>
             <modifier type="append" field="52616e67652f537065656423232344415441232323" value="Torpedo Bomber: 20cm (STR 2)">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beba-9f13-d04b-6ad6" type="instanceOf"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beba-9f13-d04b-6ad6" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Furies: 30cm
-Starhawks: 20cm
-</characteristic>
+Starhawks: 20cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4 Squadrons</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
         <profile id="76b2-41bd-7328-bb8f" name="Emperor Starboard Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <modifiers>
             <modifier type="append" field="52616e67652f537065656423232344415441232323" value="Torpedo Bomber: 20cm (STR 2)">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beba-9f13-d04b-6ad6" type="instanceOf"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beba-9f13-d04b-6ad6" type="instanceOf"/>
               </conditions>
             </modifier>
             <modifier type="append" field="52616e67652f537065656423232344415441232323" value=" Sharks: 30cm">
               <conditions>
-                <condition field="selections" scope="fd03-5f22-b33e-38dc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0775-2b9d-28d5-c715" type="atLeast"/>
+                <condition field="selections" scope="fd03-5f22-b33e-38dc" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0775-2b9d-28d5-c715" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Furies: 30cm
-Starhawks: 20cm
-</characteristic>
+Starhawks: 20cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4 Squadrons</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -7109,20 +7176,20 @@ Starhawks: 20cm
         <infoLink id="57eb-a64d-dabe-9e99" name="Sensorial Prow" hidden="false" targetId="25d6-ae61-9b39-2c57" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="6b1c-8ab9-4644-8561" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true"/>
+        <categoryLink id="6b1c-8ab9-4644-8561" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true" name="Battleship"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="d921-bab8-3429-a528" name="Extra Turret" hidden="true" collective="false" import="true" targetId="3dc9-0fe5-4b33-660e" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f11-b937-1ecf-a2f9" type="max"/>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14f7-e04f-431c-9c7e" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f11-b937-1ecf-a2f9" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14f7-e04f-431c-9c7e" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="bdb3-3d23-23e6-ca9c" name="Torpedo Bombers" hidden="true" collective="false" import="true" targetId="beba-9f13-d04b-6ad6" type="selectionEntry">
@@ -7130,7 +7197,7 @@ Starhawks: 20cm
             <modifier type="increment" field="points" value="70"/>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -7140,20 +7207,20 @@ Starhawks: 20cm
         <entryLink id="5e74-cb3b-7bb4-6ecc" name="Imperial Ordnance" hidden="false" collective="false" import="true" targetId="2da3-6f87-b676-1862" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="365.0"/>
+        <cost name="pts" typeId="points" value="365"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5307-403e-6508-c031" name="Exorcist Class Grand Cruiser" publicationId="1bc8-5968-21c3-0f27" page="16" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="8a0d-39ab-859d-28d6" name="Exorcist Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Grand Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">10</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Grand Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">10</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">3</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">3</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">3</characteristic>
           </characteristics>
         </profile>
         <profile id="1385-4aaf-c932-c62d" name="Exorcist Port Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
@@ -7161,7 +7228,7 @@ Starhawks: 20cm
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Furies: 30cm
 Starhawks: 20cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2 Squadrons</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
         <profile id="1592-2fe6-80e7-09af" name="Exorcist Starboard Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
@@ -7169,7 +7236,7 @@ Starhawks: 20cm</characteristic>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Furies: 30cm
 Starhawks: 20cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2 Squadrons</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
         <profile id="b50f-972d-7a76-15dd" name="Armored Prow" publicationId="5766-7751-d146-0800" page="23" hidden="false" typeId="5a49-6569-78e9-a35c" typeName="Special Rule">
@@ -7179,61 +7246,61 @@ Starhawks: 20cm</characteristic>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="9925-6608-e38d-ec1b" name="New CategoryLink" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="true"/>
+        <categoryLink id="9925-6608-e38d-ec1b" name="Grand Cruiser" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="2fb6-11a7-e1aa-393b" name="Famous Ships" hidden="false" collective="false" import="true" defaultSelectionEntryId="991b-02a4-8cb9-e347">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e73d-5238-8e3d-ccc4" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fff1-652b-d7dd-103e" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e73d-5238-8e3d-ccc4" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fff1-652b-d7dd-103e" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="991b-02a4-8cb9-e347" name="Standard" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="108d-73ec-f245-886b" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="108d-73ec-f245-886b" type="max"/>
               </constraints>
               <profiles>
                 <profile id="4189-d533-c71b-456e" name="Exorcist Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">8</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="763f-de43-471d-9c6b" name="Exorcist Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">8</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="68cb-2136-b770-8ff8" name="Light of Ascention" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="primary-catalogue" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ff1-709f-55a5-6daa" type="max"/>
+                <constraint field="selections" scope="primary-catalogue" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ff1-709f-55a5-6daa" type="max"/>
               </constraints>
               <profiles>
                 <profile id="1f29-a8f5-03d9-7c4b" name="Exorcist Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">10</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="92f5-58d5-3677-73f3" name="Exorcist Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">10</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -7244,40 +7311,40 @@ Starhawks: 20cm</characteristic>
         <entryLink id="8227-be63-81ff-a23c" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
         <entryLink id="09a8-0532-204f-876d" name="Shark Assault Boats" hidden="false" collective="false" import="true" targetId="0775-2b9d-28d5-c715" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="points" value="10.0">
+            <modifier type="set" field="points" value="10">
               <comment>sharks for exorcist are 10 pts not default 5. overwrite in line above</comment>
               <conditions>
-                <condition field="selections" scope="5307-403e-6508-c031" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0775-2b9d-28d5-c715" type="atLeast"/>
+                <condition field="selections" scope="5307-403e-6508-c031" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0775-2b9d-28d5-c715" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
           <costs>
-            <cost name="pts" typeId="points" value="10.0"/>
+            <cost name="pts" typeId="points" value="10"/>
           </costs>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="230.0"/>
+        <cost name="pts" typeId="points" value="230"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="39f6-6f2c-bcea-b22b" name="Mars Class Battlecruiser" publicationId="11f0-17d1-e4d2-1018" page="108" hidden="true" collective="false" import="true" type="unit">
       <profiles>
         <profile id="c992-71b0-a514-938e" name="Mars Profile" publicationId="11f0-17d1-e4d2-1018" page="108" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <modifiers>
-            <modifier type="increment" field="5475727265747323232344415441232323" value="1">
+            <modifier type="increment" field="5.475727265747323e+33" value="1">
               <conditions>
-                <condition field="selections" scope="39f6-6f2c-bcea-b22b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d10d-9781-66d7-073e" type="equalTo"/>
+                <condition field="selections" scope="39f6-6f2c-bcea-b22b" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d10d-9781-66d7-073e" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">8</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">8</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">2</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">6+Front/5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">2</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">2</characteristic>
           </characteristics>
         </profile>
         <profile id="974f-443d-7fe9-4aad" name="Port Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
@@ -7285,7 +7352,7 @@ Starhawks: 20cm</characteristic>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Furies: 30cm
 Starhawks: 20cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2 Squadrons</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
         <profile id="1546-2c37-f842-7336" name="Starboard Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
@@ -7293,28 +7360,28 @@ Starhawks: 20cm</characteristic>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Furies: 30cm
 Starhawks: 20cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2 Squadrons</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
         <profile id="7da1-09c6-5cf0-d515" name="Port Weapons battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="9fc6-9e80-d6d6-a352" name="Starboard Weapons battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="abdb-39fb-ec22-8687" name="Dorsal Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -7322,30 +7389,30 @@ Starhawks: 20cm</characteristic>
         <infoLink id="0dd4-7b87-b0ba-3af8" name="Prow Nova Cannon" hidden="false" targetId="af91-33ff-94d6-44f4" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="a291-b419-50b5-6c54" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
-        <categoryLink id="2d11-95ec-a8b7-78ae" name="Battle Cruiser" hidden="false" targetId="b041-ef69-0039-d535" primary="true"/>
+        <categoryLink id="a291-b419-50b5-6c54" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
+        <categoryLink id="2d11-95ec-a8b7-78ae" name="Battlecruiser" hidden="false" targetId="b041-ef69-0039-d535" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="d10d-9781-66d7-073e" name="+1 Turret" publicationId="5766-7751-d146-0800" page="19" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2607-6b22-9e68-6ea6" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2607-6b22-9e68-6ea6" type="max"/>
           </constraints>
           <costs>
-            <cost name="pts" typeId="points" value="10.0"/>
+            <cost name="pts" typeId="points" value="10"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="74e4-5ef7-963c-fb0f" name="Varient" hidden="false" collective="false" import="true" defaultSelectionEntryId="a6b5-a889-25ca-9709">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c827-494f-fc26-83e6" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1c4e-97ca-a237-8485" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c827-494f-fc26-83e6" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1c4e-97ca-a237-8485" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="c60a-5311-2976-901c" name="Imperious (Targeting Matrix)" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6caf-fc39-73ed-b914" type="max"/>
-                <constraint field="selections" scope="primary-catalogue" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11c4-b8e8-efac-f359" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6caf-fc39-73ed-b914" type="max"/>
+                <constraint field="selections" scope="primary-catalogue" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11c4-b8e8-efac-f359" type="max"/>
               </constraints>
               <profiles>
                 <profile id="f7e1-c67d-8dce-e9f2" name="Targeting Matrix" hidden="false" typeId="5a49-6569-78e9-a35c" typeName="Special Rule">
@@ -7355,15 +7422,15 @@ Starhawks: 20cm</characteristic>
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
+                <cost name="pts" typeId="points" value="15"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a6b5-a889-25ca-9709" name="Standard" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fd82-2e28-6e2b-2c03" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fd82-2e28-6e2b-2c03" type="max"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -7374,107 +7441,107 @@ Starhawks: 20cm</characteristic>
         <entryLink id="d64e-1733-e899-d046" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="270.0"/>
+        <cost name="pts" typeId="points" value="270"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7615-eb5a-4f3d-be40" name="Oberon Class Battleship" publicationId="b161-6b4c-e770-9ab2" page="8" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="increment" field="points" value="35">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
       <profiles>
         <profile id="9c6f-19fc-ae9f-22d2" name="Oberon Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Battleship</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">12</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">15cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Battleship</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">12</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">15cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">4</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">5</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">5</characteristic>
           </characteristics>
         </profile>
         <profile id="8cba-2f36-d154-00a9" name="Oberon Port Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <modifiers>
             <modifier type="append" field="52616e67652f537065656423232344415441232323" value="Shark Assault Boats: 30cm">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c596-4ab6-a91f-2068" type="instanceOf"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c596-4ab6-a91f-2068" type="instanceOf"/>
               </conditions>
             </modifier>
             <modifier type="append" field="52616e67652f537065656423232344415441232323" value="Torpedo Bomber: 20cm (STR 2)">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beba-9f13-d04b-6ad6" type="instanceOf"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beba-9f13-d04b-6ad6" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Furies: 30cm Starhawks: 20cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2 Squadrons</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
         <profile id="3893-ddc3-faeb-16dc" name="Oberon Starboard Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <modifiers>
             <modifier type="append" field="52616e67652f537065656423232344415441232323" value="Shark Assault Boats: 30cm">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c596-4ab6-a91f-2068" type="instanceOf"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c596-4ab6-a91f-2068" type="instanceOf"/>
               </conditions>
             </modifier>
             <modifier type="append" field="52616e67652f537065656423232344415441232323" value="Torpedo Bomber: 20cm (STR 2)">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beba-9f13-d04b-6ad6" type="instanceOf"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="beba-9f13-d04b-6ad6" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Furies: 30cm Starhawks: 20cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2 Squadrons</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
         <profile id="f7e5-2dfe-6d06-c36c" name="Oberon Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="fb75-ee58-8bd2-2972" name="Oberon Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="1972-82fa-ee3f-f978" name="Oberon Port Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="9310-3268-404a-1327" name="Oberon Starboard Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="648b-b802-0131-5b32" name="Oberon Dorsal Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">5</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
         <profile id="efa0-8a6a-221b-03ef" name="Oberon Prow Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">5</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -7483,7 +7550,7 @@ Starhawks: 20cm</characteristic>
         <infoLink id="2afb-a2d0-11f3-8043" name="Sensorial Prow" hidden="false" targetId="25d6-ae61-9b39-2c57" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="237e-13e3-45c1-eaf2" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true"/>
+        <categoryLink id="237e-13e3-45c1-eaf2" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true" name="Battleship"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="c596-4ab6-a91f-2068" name="Shark Assault Boats" hidden="false" collective="false" import="true" targetId="0775-2b9d-28d5-c715" type="selectionEntry"/>
@@ -7492,7 +7559,7 @@ Starhawks: 20cm</characteristic>
             <modifier type="increment" field="points" value="30"/>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -7500,7 +7567,7 @@ Starhawks: 20cm</characteristic>
         <entryLink id="08a1-d772-bba8-244a" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="335.0"/>
+        <cost name="pts" typeId="points" value="335"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5041-7088-764d-51b7" name="Overlord Class Battlecruiser" publicationId="11f0-17d1-e4d2-1018" page="109" hidden="true" collective="false" import="true" type="upgrade">
@@ -7509,48 +7576,47 @@ Starhawks: 20cm</characteristic>
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">8</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="b9da-288e-d9a3-18c8" name="Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">8</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="2b35-463f-f1b3-a27e" name="Dorsal Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
         <profile id="e90f-fcad-a24f-7da1" name="Prow Torpedoes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
           </characteristics>
         </profile>
         <profile id="eb83-78ff-985e-3160" name="Overlord Class Battlecruiser" publicationId="11f0-17d1-e4d2-1018" page="109" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
-          <comment>points reduction pg 19 2010 compendium
-</comment>
+          <comment>points reduction pg 19 2010 compendium</comment>
           <modifiers>
-            <modifier type="increment" field="5475727265747323232344415441232323" value="1">
+            <modifier type="increment" field="5.475727265747323e+33" value="1">
               <conditions>
-                <condition field="selections" scope="5041-7088-764d-51b7" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ce21-35fd-212c-6a16" type="equalTo"/>
+                <condition field="selections" scope="5041-7088-764d-51b7" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ce21-35fd-212c-6a16" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">8</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">8</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">2</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">6+Front/5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">2</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">2</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -7558,36 +7624,36 @@ Starhawks: 20cm</characteristic>
         <infoLink id="f4d9-7dbc-b329-31bf" name="Torpedoes" hidden="false" targetId="8103-25d2-5412-2542" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="4e8f-3e98-7d0f-9b86" name="New CategoryLink" hidden="false" targetId="b041-ef69-0039-d535" primary="true"/>
+        <categoryLink id="4e8f-3e98-7d0f-9b86" name="Battlecruiser" hidden="false" targetId="b041-ef69-0039-d535" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="70ee-fe20-becb-65f8" name="Varient" hidden="false" collective="false" import="true" defaultSelectionEntryId="c0aa-62db-b5a0-4c6b">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4307-653d-92e6-a00d" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da05-bebe-5032-0b64" type="min"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4307-653d-92e6-a00d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da05-bebe-5032-0b64" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="ce21-35fd-212c-6a16" name="Cypra Probatii (+1 Turret)" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="primary-catalogue" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d647-f823-f57a-50da" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9682-09e8-926f-0c76" type="max"/>
+                <constraint field="selections" scope="primary-catalogue" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d647-f823-f57a-50da" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9682-09e8-926f-0c76" type="max"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
+                <cost name="pts" typeId="points" value="10"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c0aa-62db-b5a0-4c6b" name="Standard" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82f3-679f-1f29-2621" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82f3-679f-1f29-2621" type="max"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3418-3d3d-bf11-0969" name="Improved Targeting Matrix" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="91b7-76fa-74e4-187d" type="max"/>
-                <constraint field="selections" scope="primary-catalogue" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f310-66b7-852f-756c" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="91b7-76fa-74e4-187d" type="max"/>
+                <constraint field="selections" scope="primary-catalogue" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f310-66b7-852f-756c" type="max"/>
               </constraints>
               <profiles>
                 <profile id="6f1f-8771-5818-b35e" name="Targeting Matrix" hidden="false" typeId="5a49-6569-78e9-a35c" typeName="Special Rule">
@@ -7597,7 +7663,7 @@ Starhawks: 20cm</characteristic>
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
+                <cost name="pts" typeId="points" value="15"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -7608,55 +7674,55 @@ Starhawks: 20cm</characteristic>
         <entryLink id="7749-9df0-116f-6565" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="220.0"/>
+        <cost name="pts" typeId="points" value="220"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c4a0-4f0a-bc98-0cfe" name="Retribution Class Battleship" publicationId="11f0-17d1-e4d2-1018" page="107" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="increment" field="points" value="35">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
       <profiles>
         <profile id="6f81-d92c-56b4-a8ea" name="Retribution Profile" publicationId="11f0-17d1-e4d2-1018" page="107" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <modifiers>
-            <modifier type="increment" field="5475727265747323232344415441232323" value="1">
+            <modifier type="increment" field="5.475727265747323e+33" value="1">
               <conditions>
-                <condition field="selections" scope="c4a0-4f0a-bc98-0cfe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8025-e5ea-9b7b-7f59" type="atLeast"/>
+                <condition field="selections" scope="c4a0-4f0a-bc98-0cfe" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8025-e5ea-9b7b-7f59" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Battleship</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">12</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Battleship</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">12</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">4</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">6+Front/ 5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">4</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">4</characteristic>
           </characteristics>
         </profile>
         <profile id="351f-a1c0-651d-13ad" name="Retribution Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">12</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="20b0-6ecd-3427-a135" name="Retribution Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">12</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="8eb7-6921-b52a-99af" name="Retribution Dorsal Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -7664,25 +7730,25 @@ Starhawks: 20cm</characteristic>
         <infoLink id="d16f-a03c-988c-ccca" name="May not use the &quot;come to new heading&quot; special order" hidden="false" targetId="b1a1-aead-ea5a-d8d3" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="ab64-6d21-2d54-c3a1" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true"/>
+        <categoryLink id="ab64-6d21-2d54-c3a1" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true" name="Battleship"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="ce6e-dbbd-882b-f221" name="Prow Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="e419-f731-0c46-ca59">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2960-1c8d-fe19-78aa" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5f0f-2504-140c-6457" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2960-1c8d-fe19-78aa" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5f0f-2504-140c-6457" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="e419-f731-0c46-ca59" name="Prow Torpedoes" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="37ed-3c68-e21b-712a" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="37ed-3c68-e21b-712a" type="max"/>
               </constraints>
               <profiles>
                 <profile id="a01c-bd72-fb05-038e" name="Prow Torpedoes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">9</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -7694,7 +7760,7 @@ Starhawks: 20cm</characteristic>
                   <modifiers>
                     <modifier type="set" field="hidden" value="false">
                       <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
                       </conditions>
                     </modifier>
                     <modifier type="increment" field="points" value="10"/>
@@ -7702,7 +7768,7 @@ Starhawks: 20cm</characteristic>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -7711,7 +7777,7 @@ Starhawks: 20cm</characteristic>
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -7725,7 +7791,7 @@ Starhawks: 20cm</characteristic>
         <entryLink id="d2d2-8448-79c2-6bcd" name="Bakka Turret" hidden="false" collective="false" import="true" targetId="8025-e5ea-9b7b-7f59" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="345.0"/>
+        <cost name="pts" typeId="points" value="345"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="932e-6f5b-65cc-38e7" name="Prow Nova Cannon" hidden="true" collective="false" import="true" type="upgrade">
@@ -7733,20 +7799,20 @@ Starhawks: 20cm</characteristic>
         <infoLink id="1aef-725f-8ed1-c800" name="Prow Nova Cannon" hidden="true" targetId="af91-33ff-94d6-44f4" type="profile"/>
       </infoLinks>
       <costs>
-        <cost name="pts" typeId="points" value="20.0"/>
+        <cost name="pts" typeId="points" value="20"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5d45-6ad5-d4cc-8570" name="Refited Torpedoes (p 156 of BFG Armada)" hidden="false" collective="false" import="true" type="upgrade">
       <costs>
-        <cost name="pts" typeId="points" value="20.0"/>
+        <cost name="pts" typeId="points" value="20"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="beba-9f13-d04b-6ad6" name="Torpedo Bombers" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
-        <categoryLink id="2349-248a-7b4a-06b3" name="New CategoryLink" hidden="false" targetId="e70d-1bf2-7ea2-276a" primary="true"/>
+        <categoryLink id="2349-248a-7b4a-06b3" name="Ordnance" hidden="false" targetId="e70d-1bf2-7ea2-276a" primary="true"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="10.0"/>
+        <cost name="pts" typeId="points" value="10"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7d8b-7a00-a7f5-06a2" name="Victory Class Battleship" publicationId="5766-7751-d146-0800" hidden="false" collective="false" import="true" type="unit">
@@ -7754,41 +7820,41 @@ Starhawks: 20cm</characteristic>
       <profiles>
         <profile id="afa0-aaaa-5bbc-1c7a" name="Victory Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <modifiers>
-            <modifier type="increment" field="5475727265747323232344415441232323" value="1">
+            <modifier type="increment" field="5.475727265747323e+33" value="1">
               <conditions>
-                <condition field="selections" scope="7d8b-7a00-a7f5-06a2" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8025-e5ea-9b7b-7f59" type="atLeast"/>
+                <condition field="selections" scope="7d8b-7a00-a7f5-06a2" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8025-e5ea-9b7b-7f59" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Battleship</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">12</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Battleship</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">12</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">4</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">6+Front/5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">4</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">4</characteristic>
           </characteristics>
         </profile>
         <profile id="d0ae-80c6-0b3c-3f92" name="Port lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="fb48-e222-a2f4-a00f" name="Starboard Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="af2f-96a5-3d24-b593" name="Dorsal Weapons battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -7796,30 +7862,30 @@ Starhawks: 20cm</characteristic>
         <infoLink id="8e77-d9a6-5d0e-997f" name="May not use the &quot;come to new heading&quot; special order" hidden="false" targetId="b1a1-aead-ea5a-d8d3" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="a338-043c-543c-a3b0" name="New CategoryLink" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true"/>
+        <categoryLink id="a338-043c-543c-a3b0" name="Battleship" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="eaa2-2d9f-540e-e52c" name="Famous Ships" hidden="false" collective="false" import="true" defaultSelectionEntryId="8c2f-c5fe-8327-0bb8">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1377-62d0-23fd-4d12" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a6e-8208-eddb-de71" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1377-62d0-23fd-4d12" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a6e-8208-eddb-de71" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="aee5-2f1c-3cab-bbbb" name="Hammer of Scaro" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7efa-4f07-ba52-e192" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7efa-4f07-ba52-e192" type="max"/>
               </constraints>
               <profiles>
                 <profile id="b7cd-6b3a-ef4a-8c3c" name="Prow Torpedoes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">9</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="-10.0"/>
+                <cost name="pts" typeId="points" value="-10"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8c2f-c5fe-8327-0bb8" name="Standard" hidden="false" collective="false" import="true" type="upgrade">
@@ -7827,7 +7893,7 @@ Starhawks: 20cm</characteristic>
                 <infoLink id="7da3-702e-3a9a-1036" name="Prow Nova Cannon" hidden="false" targetId="af91-33ff-94d6-44f4" type="profile"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -7838,65 +7904,65 @@ Starhawks: 20cm</characteristic>
         <entryLink id="3530-a023-79e5-e3a2" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
         <entryLink id="590e-87fc-703e-b348" name="Bakka Turret" hidden="false" collective="false" import="true" targetId="8025-e5ea-9b7b-7f59" type="selectionEntry">
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
+            <cost name="pts" typeId="points" value="5"/>
           </costs>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="345.0"/>
+        <cost name="pts" typeId="points" value="345"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f9b0-bc6a-0bc3-55de" name="Cardinal Class Heavy Cruiser" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="4752-b85a-77c5-9ba9" name="Cardinal Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">8</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">25cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">8</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">25cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">2</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">3</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">3</characteristic>
           </characteristics>
         </profile>
         <profile id="c339-d42e-4337-5fc7" name="Port Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="f7d4-9f08-36f9-6ff7" name="Starboard Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="ccf9-e298-0a5c-5232" name="Dorsal Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
         <profile id="3947-e7c0-3bc4-36ca" name="Prow Torpedoes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="fdc2-7024-c987-6e6b" name="New CategoryLink" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="true"/>
-        <categoryLink id="c13c-6676-ae91-ad34" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
+        <categoryLink id="fdc2-7024-c987-6e6b" name="Heavy Cruiser" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="true"/>
+        <categoryLink id="c13c-6676-ae91-ad34" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="65cf-07da-d5a1-10b0" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="190.0"/>
+        <cost name="pts" typeId="points" value="190"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="35ea-70f6-8ccc-e4e0" name="Invincible Class Fast Battleship" hidden="true" collective="false" import="true" type="unit">
@@ -7906,8 +7972,8 @@ Starhawks: 20cm</characteristic>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -7916,41 +7982,41 @@ Starhawks: 20cm</characteristic>
       <profiles>
         <profile id="aba9-e3d1-3fe7-3f3b" name="Invincible Class Fast Battleship" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Battleship</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">8</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">25cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Battleship</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">8</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">25cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">2</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">6+Front/5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">4</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">4</characteristic>
           </characteristics>
         </profile>
         <profile id="f2cb-c651-d829-939a" name="Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">12</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="1b34-7d9f-af68-2be6" name="Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">12</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="19ae-ffac-accc-086e" name="Dorsal Lance" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
         <profile id="2ced-d693-0c5a-4f71" name="Prow Torpedoes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
           </characteristics>
         </profile>
         <profile id="de6f-96e7-356e-6364" name="Invincible Class Fast Battleship" hidden="false" typeId="5a49-6569-78e9-a35c" typeName="Special Rule">
@@ -7967,41 +8033,41 @@ The ship can use &quot;Come to a New Heading&quot; orders as they have amuch hig
         <infoLink id="0a0e-069f-e9c3-88c3" name="Thunderhawk Annihilator" hidden="false" targetId="8be4-a382-7980-fad0" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="b51b-6939-aff7-e46e" name="New CategoryLink" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="true"/>
+        <categoryLink id="b51b-6939-aff7-e46e" name="Heavy Cruiser" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="208d-3f9f-d908-2f4b" name="Power Ram" hidden="false" collective="false" import="true" targetId="9818-379a-5217-d9e9" type="selectionEntry"/>
         <entryLink id="b0c5-5474-a838-972b" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="290.0"/>
+        <cost name="pts" typeId="points" value="290"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5e7d-8fbe-f68a-32a8" name="Nemesis Class Fleet Carrier" publicationId="44fa-5ffb-b627-7106" page="" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="5e7d-8fbe-f68a-32a8" name="Nemesis Class Fleet Carrier" publicationId="44fa-5ffb-b627-7106" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="d750-597a-913e-8928" name="Nemesis Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Battleship</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">12</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">15cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Battleship</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">12</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">15cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">4</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">5</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">5</characteristic>
           </characteristics>
         </profile>
         <profile id="30eb-d375-c9a2-5822" name="Dorsal Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
         <profile id="46f3-ba02-9f53-1490" name="Port Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <modifiers>
             <modifier type="append" field="46697265706f7765722f53747223232344415441232323" value=" Sharks: 30cm">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0775-2b9d-28d5-c715" type="instanceOf"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0775-2b9d-28d5-c715" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -8009,14 +8075,14 @@ The ship can use &quot;Come to a New Heading&quot; orders as they have amuch hig
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Furies: 30cm
 Starhawks: 20cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6 Squadrons</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
         <profile id="ab84-07d5-a184-cff3" name="Starboard Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <modifiers>
             <modifier type="append" field="46697265706f7765722f53747223232344415441232323" value=" Sharks: 30cm">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0775-2b9d-28d5-c715" type="instanceOf"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0775-2b9d-28d5-c715" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -8024,7 +8090,7 @@ Starhawks: 20cm</characteristic>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Furies: 30cm
 Starhawks: 20cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6 Squadrons</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -8035,73 +8101,73 @@ Starhawks: 20cm</characteristic>
         <infoLink id="c03c-0577-26c4-5912" name="May not use the &quot;come to new heading&quot; special order" hidden="false" targetId="b1a1-aead-ea5a-d8d3" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="a966-abf8-c09b-8ddb" name="New CategoryLink" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true"/>
+        <categoryLink id="a966-abf8-c09b-8ddb" name="Battleship" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="e777-122a-c9c7-1a8f" name="Shark Assault Boats" hidden="false" collective="false" import="true" targetId="0775-2b9d-28d5-c715" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="554b-0197-9c8c-1730" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="554b-0197-9c8c-1730" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="7242-371a-9734-6f73" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="400.0"/>
+        <cost name="pts" typeId="points" value="400"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4385-6d34-b150-51d5" name="Vanquisher Class Battleship" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="b508-5fdb-35a0-5403" name="Vanquisher Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <modifiers>
-            <modifier type="increment" field="5475727265747323232344415441232323" value="1">
+            <modifier type="increment" field="5.475727265747323e+33" value="1">
               <conditions>
-                <condition field="selections" scope="4385-6d34-b150-51d5" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8025-e5ea-9b7b-7f59" type="atLeast"/>
+                <condition field="selections" scope="4385-6d34-b150-51d5" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8025-e5ea-9b7b-7f59" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Battleship</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">12</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Battleship</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">12</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">4</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">6+Front/5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">4</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">4</characteristic>
           </characteristics>
         </profile>
         <profile id="a113-714f-6d36-10ae" name="Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="3848-490d-ec75-e239" name="Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="fa94-2014-ee14-3841" name="Port Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="9782-dc63-dd86-db02" name="Starboard Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="85a1-855b-7048-18bb" name="Prow Torpedoes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -8110,7 +8176,7 @@ Starhawks: 20cm</characteristic>
         <infoLink id="1bf7-5240-34cb-59fb" name="Torpedoes" hidden="false" targetId="8103-25d2-5412-2542" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="9307-925c-a6f8-2a21" name="New CategoryLink" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true"/>
+        <categoryLink id="9307-925c-a6f8-2a21" name="Battleship" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="191b-0a31-aaa6-c47a" name="Power Ram" hidden="false" collective="false" import="true" targetId="9818-379a-5217-d9e9" type="selectionEntry"/>
@@ -8118,27 +8184,27 @@ Starhawks: 20cm</characteristic>
         <entryLink id="b72d-256a-5d49-e1aa" name="Bakka Turret" hidden="false" collective="false" import="true" targetId="8025-e5ea-9b7b-7f59" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="340.0"/>
+        <cost name="pts" typeId="points" value="340"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="481c-4670-972c-f69d" name="Jovian Class Battlecruiser" publicationId="5766-7751-d146-0800" page="39" hidden="true" collective="false" import="true" type="unit">
       <profiles>
         <profile id="30e4-0071-1e21-3af4" name="Jovian Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">8</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">8</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">2</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">6+Front/5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">2</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">2</characteristic>
           </characteristics>
         </profile>
-        <profile id="6d19-5170-d65c-91d8" name="Dorsal Lance Battery" page="" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
+        <profile id="6d19-5170-d65c-91d8" name="Dorsal Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
         <profile id="87e2-eb6a-29d9-1002" name="Port Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
@@ -8146,7 +8212,7 @@ Starhawks: 20cm</characteristic>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Furies: 30cm
 Starhawks: 20cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3 Squadrons</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
         <profile id="f46c-6e87-bd7f-b6a9" name="Starboard Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
@@ -8154,7 +8220,7 @@ Starhawks: 20cm</characteristic>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Furies: 30cm
 Starhawks: 20cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3 Squadrons</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
         <profile id="f42a-9d3a-f42d-8744" name="Jovian  (Reserve Vessel)" hidden="false" typeId="5a49-6569-78e9-a35c" typeName="Special Rule">
@@ -8165,69 +8231,69 @@ The Jovian is a unique vessel. Only one may be included in an Imperial fleet. It
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="f07b-f2e7-1fd5-6a3b" name="Battle Cruiser" hidden="false" targetId="b041-ef69-0039-d535" primary="true"/>
+        <categoryLink id="f07b-f2e7-1fd5-6a3b" name="Battlecruiser" hidden="false" targetId="b041-ef69-0039-d535" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="cbb1-1fce-0f79-50b5" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
         <entryLink id="5dad-3fcb-6ff5-145b" name="Imperial Ordnance" hidden="false" collective="false" import="true" targetId="2da3-6f87-b676-1862" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="260.0"/>
+        <cost name="pts" typeId="points" value="260"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a332-3718-ef1b-57f3" name="Orion Class Battlecruiser" hidden="true" collective="false" import="true" type="unit">
       <profiles>
         <profile id="d813-246b-edd9-a31a" name="Orion Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">8</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">15cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">8</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">15cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">2</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">6+Front/5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">2</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">2</characteristic>
           </characteristics>
         </profile>
         <profile id="5bd9-dea1-9cab-5340" name="Port Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="6212-ab21-dcfe-df41" name="Starboard Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="b176-f5ca-b792-ddda" name="Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="5e5a-5cc9-62c9-31e9" name="Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="808e-52ec-7278-ec85" name="Prow Torpedoes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
           </characteristics>
         </profile>
         <profile id="3893-e4be-7999-1eeb" name="Dorsal Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -8235,26 +8301,26 @@ The Jovian is a unique vessel. Only one may be included in an Imperial fleet. It
         <infoLink id="39ef-6e10-e8eb-10ba" name="Torpedoes" hidden="false" targetId="8103-25d2-5412-2542" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="138a-da66-b371-9938" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
-        <categoryLink id="f1a4-e889-03ea-c306" name="New CategoryLink" hidden="false" targetId="b041-ef69-0039-d535" primary="true"/>
+        <categoryLink id="138a-da66-b371-9938" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
+        <categoryLink id="f1a4-e889-03ea-c306" name="Battlecruiser" hidden="false" targetId="b041-ef69-0039-d535" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="a67f-20d0-f1f4-0cd4" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="215.0"/>
+        <cost name="pts" typeId="points" value="215"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="61f6-1b5d-3cd7-fb30" name="Sword Frigate" publicationId="11f0-17d1-e4d2-1018" page="113" hidden="true" collective="false" import="true" type="unit">
       <modifiers>
-        <modifier type="increment" field="points" value="5.0">
+        <modifier type="increment" field="points" value="5">
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7346-ab43-9438-149f" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82c2-f360-d49f-cb84" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5b8b-7613-df6a-8977" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6577-54b5-e6c6-11c5" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7346-ab43-9438-149f" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82c2-f360-d49f-cb84" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5b8b-7613-df6a-8977" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6577-54b5-e6c6-11c5" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -8263,39 +8329,39 @@ The Jovian is a unique vessel. Only one may be included in an Imperial fleet. It
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed8-4a6a-2f2b-833d" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed8-4a6a-2f2b-833d" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6a0c-e137-bdf1-9e5b" type="max"/>
+        <constraint field="selections" scope="parent" value="6" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6a0c-e137-bdf1-9e5b" type="max"/>
       </constraints>
       <profiles>
         <profile id="ef05-12b5-6172-0e5a" name="Sword Class Frigate" publicationId="11f0-17d1-e4d2-1018" page="113" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Escort</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">1</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">25</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Escort</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">1</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">25</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">90</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">2</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">2</characteristic>
           </characteristics>
         </profile>
         <profile id="8831-b689-d0bb-6272" name="Sword Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/right/front</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/right/front</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -8303,10 +8369,10 @@ The Jovian is a unique vessel. Only one may be included in an Imperial fleet. It
         <infoLink id="6aac-ddbe-657e-ba49" name="Rapid Strike Vessels" hidden="false" targetId="3c73-8a2f-5cbd-932b" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="1326-f559-9837-ab36" hidden="false" targetId="4573636f72747323232344415441232323" primary="true"/>
+        <categoryLink id="1326-f559-9837-ab36" hidden="false" targetId="4573636f72747323232344415441232323" primary="true" name="Escort"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="35.0"/>
+        <cost name="pts" typeId="points" value="35"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="eb31-03ad-c769-4fe6" name="Firestorm Frigate" publicationId="11f0-17d1-e4d2-1018" page="113" hidden="true" collective="false" import="true" type="unit">
@@ -8315,11 +8381,11 @@ The Jovian is a unique vessel. Only one may be included in an Imperial fleet. It
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7346-ab43-9438-149f" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82c2-f360-d49f-cb84" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5b8b-7613-df6a-8977" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6577-54b5-e6c6-11c5" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7346-ab43-9438-149f" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82c2-f360-d49f-cb84" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5b8b-7613-df6a-8977" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6577-54b5-e6c6-11c5" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -8328,53 +8394,53 @@ The Jovian is a unique vessel. Only one may be included in an Imperial fleet. It
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed8-4a6a-2f2b-833d" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed8-4a6a-2f2b-833d" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bd5b-4abf-9cac-02ae" type="max"/>
+        <constraint field="selections" scope="parent" value="6" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bd5b-4abf-9cac-02ae" type="max"/>
       </constraints>
       <profiles>
         <profile id="2278-843e-0e95-8cac" name="Firestorm Class Frigate" publicationId="11f0-17d1-e4d2-1018" page="113" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Escort/1</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">1</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">25</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Escort/1</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">1</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">25</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">90</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">2</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">2</characteristic>
           </characteristics>
         </profile>
         <profile id="6973-e14c-d342-59ca" name="Firestorm Prow Lance" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
           </characteristics>
         </profile>
         <profile id="1d6b-eb51-d3af-9959" name="Firestorm Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/right/front</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/right/front</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="8ed8-f655-40dd-f548" hidden="false" targetId="4573636f72747323232344415441232323" primary="true"/>
+        <categoryLink id="8ed8-f655-40dd-f548" hidden="false" targetId="4573636f72747323232344415441232323" primary="true" name="Escort"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="40.0"/>
+        <cost name="pts" typeId="points" value="40"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="fd70-2a36-263f-1ab7" name="Cobra Destroyer" publicationId="11f0-17d1-e4d2-1018" page="114" hidden="true" collective="false" import="true" type="unit">
@@ -8383,59 +8449,59 @@ The Jovian is a unique vessel. Only one may be included in an Imperial fleet. It
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed8-4a6a-2f2b-833d" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed8-4a6a-2f2b-833d" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5a12-a17e-f21b-0631" type="max"/>
+        <constraint field="selections" scope="parent" value="6" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5a12-a17e-f21b-0631" type="max"/>
       </constraints>
       <profiles>
         <profile id="930c-ac44-399c-c1cf" name="Cobra Class Destroyer" publicationId="11f0-17d1-e4d2-1018" page="114" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Escort</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">1</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">30</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Escort</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">1</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">30</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">90</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">4+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">1</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">1</characteristic>
           </characteristics>
         </profile>
         <profile id="b61a-1001-ccba-b312" name="Cobra Prow Torpedos" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
           </characteristics>
         </profile>
         <profile id="2cb7-838e-ae3b-6392" name="Cobra Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <modifiers>
-            <modifier type="set" field="46697265706f7765722f53747223232344415441232323" value="0.0">
+            <modifier type="set" field="46697265706f7765722f53747223232344415441232323" value="0">
               <conditions>
-                <condition field="selections" scope="fd70-2a36-263f-1ab7" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dc88-f7ed-8352-4f11" type="atLeast"/>
+                <condition field="selections" scope="fd70-2a36-263f-1ab7" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dc88-f7ed-8352-4f11" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
         <profile id="32d5-ab38-34ca-8805" name="24th Destroyer Squadron &apos;Widowmaker&apos;" hidden="true" typeId="5a49-6569-78e9-a35c" typeName="Special Rule">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="fd70-2a36-263f-1ab7" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dc88-f7ed-8352-4f11" type="atLeast"/>
+                <condition field="selections" scope="fd70-2a36-263f-1ab7" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dc88-f7ed-8352-4f11" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -8453,10 +8519,10 @@ The Jovian is a unique vessel. Only one may be included in an Imperial fleet. It
         <infoLink id="8813-194c-1f7e-a601" name="Torpedoes" hidden="false" targetId="8103-25d2-5412-2542" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="4b3a-5546-cfc2-93d3" hidden="false" targetId="4573636f72747323232344415441232323" primary="true"/>
+        <categoryLink id="4b3a-5546-cfc2-93d3" hidden="false" targetId="4573636f72747323232344415441232323" primary="true" name="Escort"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="30.0"/>
+        <cost name="pts" typeId="points" value="30"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2466-9136-a2e0-ee08" name="Falchion Frigate" publicationId="1bc8-5968-21c3-0f27" page="19" hidden="true" collective="false" import="true" type="unit">
@@ -8465,10 +8531,10 @@ The Jovian is a unique vessel. Only one may be included in an Imperial fleet. It
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7346-ab43-9438-149f" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82c2-f360-d49f-cb84" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5b8b-7613-df6a-8977" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6577-54b5-e6c6-11c5" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7346-ab43-9438-149f" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="82c2-f360-d49f-cb84" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5b8b-7613-df6a-8977" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6577-54b5-e6c6-11c5" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -8477,41 +8543,41 @@ The Jovian is a unique vessel. Only one may be included in an Imperial fleet. It
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0335-3148-5471-abe3" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8257-c812-685a-d29e" type="max"/>
+        <constraint field="selections" scope="parent" value="6" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8257-c812-685a-d29e" type="max"/>
       </constraints>
       <profiles>
         <profile id="2005-e3a2-4eef-c99f" name="Falchion Profile" publicationId="1bc8-5968-21c3-0f27" page="19" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Escort</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">1</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">25cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Escort</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">1</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">25cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">90°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">1</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">1</characteristic>
           </characteristics>
         </profile>
         <profile id="570b-9f0f-2b1d-8295" name="Falchion Prow Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
         <profile id="c0d4-be9a-1d16-579a" name="Falchion Prow Torpedoes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -8519,10 +8585,10 @@ The Jovian is a unique vessel. Only one may be included in an Imperial fleet. It
         <infoLink id="fa46-f4e3-16cc-b99c" name="Torpedoes" hidden="false" targetId="8103-25d2-5412-2542" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="2d57-b706-8215-94dc" hidden="false" targetId="4573636f72747323232344415441232323" primary="true"/>
+        <categoryLink id="2d57-b706-8215-94dc" hidden="false" targetId="4573636f72747323232344415441232323" primary="true" name="Escort"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="35.0"/>
+        <cost name="pts" typeId="points" value="35"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="be17-9b09-4b35-2f65" name="Viper Class Destroyer" publicationId="5766-7751-d146-0800" page="43" hidden="true" collective="false" import="true" type="unit">
@@ -8531,33 +8597,33 @@ The Jovian is a unique vessel. Only one may be included in an Imperial fleet. It
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5d6c-ba37-f984-238e" type="max"/>
+        <constraint field="selections" scope="parent" value="6" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5d6c-ba37-f984-238e" type="max"/>
       </constraints>
       <profiles>
         <profile id="16d8-8179-afa5-a572" name="Viper Profile" publicationId="5766-7751-d146-0800" page="43" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Escort</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">1</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">30cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Escort</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">1</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">30cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">90°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">4+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">1</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">1</characteristic>
           </characteristics>
         </profile>
         <profile id="0df9-9e40-1df7-43d4" name="Viper Prow Torpedoes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
           </characteristics>
         </profile>
         <profile id="79b0-1faa-9d1b-9911" name="Fatigue" hidden="true" typeId="5a49-6569-78e9-a35c" typeName="Special Rule">
@@ -8571,42 +8637,42 @@ The Jovian is a unique vessel. Only one may be included in an Imperial fleet. It
         <infoLink id="627e-41f9-4043-8a91" name="Torpedoes" hidden="false" targetId="8103-25d2-5412-2542" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="342f-7087-696c-d7b4" name="Escorts" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
+        <categoryLink id="342f-7087-696c-d7b4" name="Escort" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="35.0"/>
+        <cost name="pts" typeId="points" value="35"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="032c-e71b-b86c-acdf" name="Extra Turret" hidden="true" collective="false" import="true" type="upgrade">
       <costs>
-        <cost name="pts" typeId="points" value="5.0"/>
+        <cost name="pts" typeId="points" value="5"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9e60-dcbc-5fe8-e8e0" name="Dominion Class Battlecruiser" publicationId="5766-7751-d146-0800" page="40" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="3d06-25cf-9bd7-28cd" name="Dominion Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <modifiers>
-            <modifier type="increment" field="5475727265747323232344415441232323" value="1">
+            <modifier type="increment" field="5.475727265747323e+33" value="1">
               <conditions>
-                <condition field="selections" scope="9e60-dcbc-5fe8-e8e0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8025-e5ea-9b7b-7f59" type="atLeast"/>
+                <condition field="selections" scope="9e60-dcbc-5fe8-e8e0" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8025-e5ea-9b7b-7f59" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">8</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">8</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">2</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">6+Front/5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">3</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">3</characteristic>
           </characteristics>
         </profile>
-        <profile id="b3a4-a2e1-cded-0864" name="Dorsal Lance Battery" page="" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
+        <profile id="b3a4-a2e1-cded-0864" name="Dorsal Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
         <profile id="63f1-9de9-975c-9357" name="Port Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
@@ -8614,7 +8680,7 @@ The Jovian is a unique vessel. Only one may be included in an Imperial fleet. It
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Furies: 30cm
 Starhawks: 20cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2 Squadrons</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
         <profile id="38d5-90dd-fb9c-a733" name="Starboard Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
@@ -8622,33 +8688,33 @@ Starhawks: 20cm</characteristic>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Furies: 30cm
 Starhawks: 20cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2 Squadrons</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
         <profile id="0024-6d96-2604-0dd7" name="Dominion Port Lance Batteries" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="0714-a481-86da-dfa1" name="Dominion Starbord Lance Batteries" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="eb2b-fa3c-d13f-1c0e" name="Dominion Prow Torpedoes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Speed: 30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="86f9-4980-6003-1b32" name="New CategoryLink" hidden="false" targetId="b041-ef69-0039-d535" primary="true"/>
+        <categoryLink id="86f9-4980-6003-1b32" name="Battlecruiser" hidden="false" targetId="b041-ef69-0039-d535" primary="true"/>
         <categoryLink id="a6aa-1470-9ee0-9a24" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
       </categoryLinks>
       <entryLinks>
@@ -8657,41 +8723,41 @@ Starhawks: 20cm</characteristic>
         <entryLink id="88f7-7bd2-637b-9c66" name="Bakka Turret" hidden="false" collective="false" import="true" targetId="8025-e5ea-9b7b-7f59" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="260.0"/>
+        <cost name="pts" typeId="points" value="260"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="31a2-b84a-598f-e15a" name="Mercury Class Battlecruiser" publicationId="11f0-17d1-e4d2-1018" page="108" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="0893-f0be-0eaf-b6b5" name="Mercury Profile" publicationId="11f0-17d1-e4d2-1018" page="108" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <modifiers>
-            <modifier type="increment" field="5475727265747323232344415441232323" value="1">
+            <modifier type="increment" field="5.475727265747323e+33" value="1">
               <conditions>
-                <condition field="selections" scope="31a2-b84a-598f-e15a" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8025-e5ea-9b7b-7f59" type="atLeast"/>
+                <condition field="selections" scope="31a2-b84a-598f-e15a" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8025-e5ea-9b7b-7f59" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">8</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">8</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">2</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">6+Front/5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">2</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">2</characteristic>
           </characteristics>
         </profile>
         <profile id="1e88-0398-8736-4d7e" name="Port Main Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="477a-8b4a-eb43-3ebd" name="Starboard Main Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="b4e7-bd2d-2b6f-2e33" name="Port Weapons battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
@@ -8700,8 +8766,8 @@ Starhawks: 20cm</characteristic>
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="31a2-b84a-598f-e15a" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e47e-c5ed-8b31-3217" type="equalTo"/>
-                    <condition field="selections" scope="31a2-b84a-598f-e15a" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a00d-09e5-4ef0-d6b6" type="equalTo"/>
+                    <condition field="selections" scope="31a2-b84a-598f-e15a" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e47e-c5ed-8b31-3217" type="equalTo"/>
+                    <condition field="selections" scope="31a2-b84a-598f-e15a" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a00d-09e5-4ef0-d6b6" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -8710,7 +8776,7 @@ Starhawks: 20cm</characteristic>
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="bb20-faef-bc2e-81d6" name="Starboard Weapons battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
@@ -8719,8 +8785,8 @@ Starhawks: 20cm</characteristic>
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="31a2-b84a-598f-e15a" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e47e-c5ed-8b31-3217" type="equalTo"/>
-                    <condition field="selections" scope="31a2-b84a-598f-e15a" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a00d-09e5-4ef0-d6b6" type="equalTo"/>
+                    <condition field="selections" scope="31a2-b84a-598f-e15a" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e47e-c5ed-8b31-3217" type="equalTo"/>
+                    <condition field="selections" scope="31a2-b84a-598f-e15a" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a00d-09e5-4ef0-d6b6" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -8729,14 +8795,14 @@ Starhawks: 20cm</characteristic>
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="1beb-7309-0978-667e" name="Dorsal Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
         <profile id="1c98-4a6f-7835-b6f5" name="Unstable Reactor" hidden="false" typeId="5a49-6569-78e9-a35c" typeName="Special Rule">
@@ -8750,65 +8816,65 @@ Starhawks: 20cm</characteristic>
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="31a2-b84a-598f-e15a" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e25e-bb08-f98c-c061" type="equalTo"/>
+                <condition field="selections" scope="31a2-b84a-598f-e15a" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e25e-bb08-f98c-c061" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="e2ee-ae1a-d79f-a070" name="New CategoryLink" hidden="false" targetId="b041-ef69-0039-d535" primary="true"/>
+        <categoryLink id="e2ee-ae1a-d79f-a070" name="Battlecruiser" hidden="false" targetId="b041-ef69-0039-d535" primary="true"/>
         <categoryLink id="6518-6646-8f24-5b81" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="bdde-04a9-6d2e-d828" name="Varient" hidden="false" collective="false" import="true" defaultSelectionEntryId="3380-270b-8c0b-feaa">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1038-b377-5864-026e" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d03c-41fc-2f0e-7164" type="min"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1038-b377-5864-026e" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d03c-41fc-2f0e-7164" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="a00d-09e5-4ef0-d6b6" name="Medusa (Improved Range)" publicationId="5766-7751-d146-0800" page="41" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="10cc-e6a2-e671-6483" type="max"/>
-                <constraint field="selections" scope="primary-catalogue" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="46b1-f3ae-cebe-8d16" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="10cc-e6a2-e671-6483" type="max"/>
+                <constraint field="selections" scope="primary-catalogue" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="46b1-f3ae-cebe-8d16" type="max"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
+                <cost name="pts" typeId="points" value="10"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3380-270b-8c0b-feaa" name="Standard" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="62cf-8d11-5e80-63bb" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="62cf-8d11-5e80-63bb" type="max"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e25e-bb08-f98c-c061" name="Gorgon (Torpedos)" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4c0a-301a-ee72-76e8" type="max"/>
-                <constraint field="selections" scope="primary-catalogue" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f40a-88d6-5bf3-eae4" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4c0a-301a-ee72-76e8" type="max"/>
+                <constraint field="selections" scope="primary-catalogue" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f40a-88d6-5bf3-eae4" type="max"/>
               </constraints>
               <profiles>
                 <profile id="f590-da7b-b4a7-df14" name="Prow Torpedos" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="-20.0"/>
+                <cost name="pts" typeId="points" value="-20"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e47e-c5ed-8b31-3217" name="Nemesis (Improved Range)" publicationId="5766-7751-d146-0800" page="41" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5cc3-5118-ff7a-1546" type="max"/>
-                <constraint field="selections" scope="primary-catalogue" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6704-8b88-bb02-e14c" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5cc3-5118-ff7a-1546" type="max"/>
+                <constraint field="selections" scope="primary-catalogue" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6704-8b88-bb02-e14c" type="max"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
+                <cost name="pts" typeId="points" value="10"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -8819,7 +8885,7 @@ Starhawks: 20cm</characteristic>
         <entryLink id="1a6e-4462-e98b-fac5" name="Bakka Turret" hidden="false" collective="false" import="true" targetId="8025-e5ea-9b7b-7f59" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="255.0"/>
+        <cost name="pts" typeId="points" value="255"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8025-e5ea-9b7b-7f59" name="Bakka Turret" hidden="true" collective="false" import="true" type="upgrade">
@@ -8827,18 +8893,18 @@ Starhawks: 20cm</characteristic>
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e874-e62b-1c36-7aec" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a7a-d4c0-7269-6693" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a7a-d4c0-7269-6693" type="max"/>
       </constraints>
       <infoLinks>
         <infoLink id="1f7d-986d-7a83-ea45" name="Bakka Turret" hidden="false" targetId="b473-f084-d220-f2c8" type="profile"/>
       </infoLinks>
       <costs>
-        <cost name="pts" typeId="points" value="5.0"/>
+        <cost name="pts" typeId="points" value="5"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3c40-c6be-29e9-75d8" name="Xenos Vessel" hidden="true" collective="false" import="true" type="model">
@@ -8847,8 +8913,8 @@ Starhawks: 20cm</characteristic>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -8857,56 +8923,56 @@ Starhawks: 20cm</characteristic>
       <profiles>
         <profile id="7435-e8dc-fb2e-267e" name="Xenos Vessel Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <modifiers>
-            <modifier type="append" field="537065656423232344415441232323" value="+5cm">
+            <modifier type="append" field="5.370656564232324e+29" value="+5cm">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="03d0-db64-cb60-7a4f" type="instanceOf"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="03d0-db64-cb60-7a4f" type="instanceOf"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="5475727265747323232344415441232323" value="1">
+            <modifier type="increment" field="5.475727265747323e+33" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bbac-40dd-b1d7-11b0" type="instanceOf"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bbac-40dd-b1d7-11b0" type="instanceOf"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="536869656c647323232344415441232323" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ead5-ee32-7ba3-5622" type="instanceOf"/>
+                <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ead5-ee32-7ba3-5622" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Escort</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">1</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">25cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Escort</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">1</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">25cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">1</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">1</characteristic>
           </characteristics>
         </profile>
         <profile id="4fa9-9e24-aa98-c355" name="Weapons battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
         <profile id="59da-f615-ea9b-466d" name="Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="818f-a8ef-1bc1-f250" name="New CategoryLink" hidden="false" targetId="4573636f72747323232344415441232323" primary="true"/>
+        <categoryLink id="818f-a8ef-1bc1-f250" name="Escort" hidden="false" targetId="4573636f72747323232344415441232323" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="c1a4-4983-d282-8c43" name="Xenotech Systems (roll a D6)" hidden="false" collective="false" import="true">
           <selectionEntries>
             <selectionEntry id="f55a-f1b1-ef91-42cc" name="1 Long Range Sensors" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad9f-6ee3-bdcb-a7a9" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad9f-6ee3-bdcb-a7a9" type="max"/>
               </constraints>
               <profiles>
                 <profile id="dd92-7f83-f68a-e3f5" name="1 Long Range Sensors" hidden="false" typeId="5a49-6569-78e9-a35c" typeName="Special Rule">
@@ -8916,12 +8982,12 @@ Starhawks: 20cm</characteristic>
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2ae1-93d9-c95b-94f2" name="2 Targetting Matrix" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c21e-f1f2-a89f-504b" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c21e-f1f2-a89f-504b" type="max"/>
               </constraints>
               <profiles>
                 <profile id="1aec-6fc0-9630-2bbf" name="2 Targetting Matrix" hidden="false" typeId="5a49-6569-78e9-a35c" typeName="Special Rule">
@@ -8931,12 +8997,12 @@ Starhawks: 20cm</characteristic>
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ead5-ee32-7ba3-5622" name="3 Advanced Shielding" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23a2-bec5-15ca-a320" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23a2-bec5-15ca-a320" type="max"/>
               </constraints>
               <profiles>
                 <profile id="b9ab-681d-8c4b-2fe7" name="Advanced Shielding" hidden="false" typeId="5a49-6569-78e9-a35c" typeName="Special Rule">
@@ -8946,12 +9012,12 @@ Starhawks: 20cm</characteristic>
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bbac-40dd-b1d7-11b0" name="4 Ship Defence Grid" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f05-dfc0-7070-679b" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f05-dfc0-7070-679b" type="max"/>
               </constraints>
               <profiles>
                 <profile id="5c88-df82-3561-8c55" name="4 Ship Defence Grid" hidden="false" typeId="5a49-6569-78e9-a35c" typeName="Special Rule">
@@ -8961,12 +9027,12 @@ Starhawks: 20cm</characteristic>
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="59f4-4276-8264-6176" name="5 Adanced Drive Technology" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e9d-575d-aaed-6a9e" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e9d-575d-aaed-6a9e" type="max"/>
               </constraints>
               <profiles>
                 <profile id="e572-3ccf-5672-51ae" name="5 Adanced Drive Technology" hidden="false" typeId="5a49-6569-78e9-a35c" typeName="Special Rule">
@@ -8976,15 +9042,15 @@ Starhawks: 20cm</characteristic>
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="670c-8537-9854-63e8" name="6 Pick one of the above" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cadb-70d4-54e7-11b8" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cadb-70d4-54e7-11b8" type="max"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -8994,7 +9060,7 @@ Starhawks: 20cm</characteristic>
         <entryLink id="da19-3fcd-9e42-acc8" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="60.0"/>
+        <cost name="pts" typeId="points" value="60"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="eff8-dbf4-5ac6-ddb9" name="Cargo Vessel" hidden="false" collective="false" import="true" type="upgrade">
@@ -9003,8 +9069,8 @@ Starhawks: 20cm</characteristic>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -9013,25 +9079,25 @@ Starhawks: 20cm</characteristic>
       <profiles>
         <profile id="3785-19c6-3e6c-2ade" name="Cargo Vessel" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Escort</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">1</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">25</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Escort</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">1</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">25</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">1</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">1</characteristic>
           </characteristics>
         </profile>
         <profile id="f093-fd32-c7c9-7634" name="Cargo Vessel Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <costs>
-        <cost name="pts" typeId="points" value="20.0"/>
+        <cost name="pts" typeId="points" value="20"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e79b-d6c9-99ca-4565" name="Cargo Transport" hidden="false" collective="false" import="true" type="upgrade">
@@ -9040,8 +9106,8 @@ Starhawks: 20cm</characteristic>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70d0-c8dc-b8b6-a258" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -9050,25 +9116,25 @@ Starhawks: 20cm</characteristic>
       <profiles>
         <profile id="16ad-d2b5-8c8c-e80b" name="Cargo Transport" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Escort</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">1</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">15</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Escort</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">1</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">15</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">1</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">1</characteristic>
           </characteristics>
         </profile>
         <profile id="9a9f-8cec-e241-6ed8" name="Cargo Transport Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">15cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <costs>
-        <cost name="pts" typeId="points" value="10.0"/>
+        <cost name="pts" typeId="points" value="10"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="dc88-f7ed-8352-4f11" name="Widowmaker Cobra" hidden="true" collective="false" import="true" type="upgrade">
@@ -9077,18 +9143,18 @@ Starhawks: 20cm</characteristic>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed8-4a6a-2f2b-833d" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb02-283b-cb5e-e4ea" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5b11-b7cd-f654" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ed8-4a6a-2f2b-833d" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02c6-8a9e-e53a-3a55" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02c6-8a9e-e53a-3a55" type="max"/>
       </constraints>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -9097,36 +9163,36 @@ Starhawks: 20cm</characteristic>
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="primary-catalogue" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cdc1-e60c-6456-c57a" type="notInstanceOf"/>
+            <condition field="selections" scope="primary-catalogue" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cdc1-e60c-6456-c57a" type="notInstanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="114d-cd86-c154-dade" type="max"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c81d-35af-41f5-4f54" type="min"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="114d-cd86-c154-dade" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c81d-35af-41f5-4f54" type="min"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="5e3d-1926-ea29-8ade" name="Thunderhawk Gunship" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6496-ab4b-9748-e6c5" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6496-ab4b-9748-e6c5" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="fcbd-c5c8-07af-1455" name="Thunderhawk Gunship" hidden="false" targetId="843f-ef90-8376-4f0b" type="profile"/>
           </infoLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6eb3-27d5-d69e-f79b" name="Thunderhawk Annihilator" hidden="true" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6273-7e00-f820-6799" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6273-7e00-f820-6799" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="2e4f-6f75-13e2-5cc7" name="Thunderhawk Annihilator" hidden="false" targetId="8be4-a382-7980-fad0" type="profile"/>
@@ -9135,7 +9201,7 @@ Starhawks: 20cm</characteristic>
             <categoryLink id="0f80-f206-58e4-d63b" name="Ordnance" hidden="false" targetId="e70d-1bf2-7ea2-276a" primary="false"/>
           </categoryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -9164,7 +9230,7 @@ Starhawks: 20cm</characteristic>
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
+            <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24a3-f4ab-d475-1a63" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -9176,7 +9242,7 @@ Starhawks: 20cm</characteristic>
       <characteristics>
         <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30-150cm</characteristic>
         <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1</characteristic>
-        <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+        <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
       </characteristics>
     </profile>
     <profile id="25d6-ae61-9b39-2c57" name="Sensorial Prow" hidden="false" typeId="5a49-6569-78e9-a35c" typeName="Special Rule">

--- a/Space Marines.cat
+++ b/Space Marines.cat
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="e1d46d07-b8eb-45a7-b222-5412767d2ff8" name="Space Marines" revision="13" battleScribeVersion="2.03" authorName="BSData" authorContact="@DndTonight @BSData" authorUrl="http://battlescribedata.appspot.com/#/repo/battlefleetgothic" library="false" gameSystemId="de5d6c5f-ae7b-4dd1-841e-5f1193fb5176" gameSystemRevision="46" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="e1d46d07-b8eb-45a7-b222-5412767d2ff8" name="Space Marines" revision="14" battleScribeVersion="2.03" authorName="BSData" authorContact="@DndTonight @BSData" authorUrl="http://battlescribedata.appspot.com/#/repo/battlefleetgothic" library="false" gameSystemId="de5d6c5f-ae7b-4dd1-841e-5f1193fb5176" gameSystemRevision="46" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <forceEntries>
     <forceEntry id="a2b7-61cb-e479-de43" name="Codex Astartes Fleet List" publicationId="1bc8-5968-21c3-0f27" page="30" hidden="false">
       <categoryLinks>
-        <categoryLink id="361a-a044-5406-a70f" name="Battlecruisers &amp; Heavy Cruisers" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
-        <categoryLink id="709c-9150-cde7-8bd8" name="Battleships" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false">
+        <categoryLink id="361a-a044-5406-a70f" name="Heavy Cruiser" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
+        <categoryLink id="709c-9150-cde7-8bd8" name="Battleship" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false">
           <modifiers>
-            <modifier type="increment" field="077a-c6b8-4df7-54f3" value="1.0">
+            <modifier type="increment" field="077a-c6b8-4df7-54f3" value="1">
               <repeats>
-                <repeat field="points" scope="force" value="1000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" repeats="1" roundUp="false"/>
+                <repeat field="points" scope="force" value="1000" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" repeats="1" roundUp="false"/>
               </repeats>
               <conditions>
-                <condition field="points" scope="force" value="1000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="greaterThan"/>
+                <condition field="points" scope="force" value="1000" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="077a-c6b8-4df7-54f3" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="077a-c6b8-4df7-54f3" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="4b3a-94a1-5e04-c435" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
-        <categoryLink id="d0ab-dbea-4a50-4549" name="Escorts" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
-        <categoryLink id="5622-35a0-fcdc-0c03" name="Fleet Commanders" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="false">
+        <categoryLink id="4b3a-94a1-5e04-c435" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
+        <categoryLink id="d0ab-dbea-4a50-4549" name="Escort" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
+        <categoryLink id="5622-35a0-fcdc-0c03" name="Fleet Commander" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="false">
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bfa-eac1-a95d-cb90" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bfa-eac1-a95d-cb90" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="4d90-850e-0928-f78c" name="Grand Cruisers" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false"/>
-        <categoryLink id="532a-ef1c-938f-5632" name="Orbital Defences" hidden="false" targetId="90ac-0bee-0c90-be27" primary="false"/>
+        <categoryLink id="4d90-850e-0928-f78c" name="Grand Cruiser" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false"/>
+        <categoryLink id="532a-ef1c-938f-5632" name="Orbital Defence" hidden="false" targetId="90ac-0bee-0c90-be27" primary="false"/>
         <categoryLink id="96bc-7c5b-2a13-8ded" name="Ordnance" hidden="false" targetId="e70d-1bf2-7ea2-276a" primary="false"/>
         <categoryLink id="d24f-915e-7f78-81ba" name="Special" hidden="false" targetId="5370656369616c23232344415441232323" primary="false"/>
         <categoryLink id="e5d8-ec4c-f977-f31e" name="Reserves" hidden="false" targetId="9624-17a2-bfd7-6420" primary="false"/>
@@ -35,31 +35,31 @@
     </forceEntry>
     <forceEntry id="5401-792b-71dc-1a0d" name="Crusade Fleet List" publicationId="5766-7751-d146-0800" page="60" hidden="false">
       <categoryLinks>
-        <categoryLink id="9db4-a059-7447-db44" name="Battlecruisers &amp; Heavy Cruisers" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
-        <categoryLink id="f497-fee2-6909-10aa" name="Battleships" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false">
+        <categoryLink id="9db4-a059-7447-db44" name="Heavy Cruiser" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
+        <categoryLink id="f497-fee2-6909-10aa" name="Battleship" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false">
           <modifiers>
-            <modifier type="increment" field="f7f0-4f4a-ee3f-5e2f" value="1.0">
+            <modifier type="increment" field="f7f0-4f4a-ee3f-5e2f" value="1">
               <repeats>
-                <repeat field="points" scope="force" value="1000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" repeats="1" roundUp="false"/>
+                <repeat field="points" scope="force" value="1000" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" repeats="1" roundUp="false"/>
               </repeats>
               <conditions>
-                <condition field="points" scope="force" value="1000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="greaterThan"/>
+                <condition field="points" scope="force" value="1000" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7f0-4f4a-ee3f-5e2f" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7f0-4f4a-ee3f-5e2f" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="fc79-85e0-8256-055b" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
-        <categoryLink id="d956-aef6-60d0-10f4" name="Escorts" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
-        <categoryLink id="3c38-84d1-499c-b29f" name="Fleet Commanders" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="false">
+        <categoryLink id="fc79-85e0-8256-055b" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
+        <categoryLink id="d956-aef6-60d0-10f4" name="Escort" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
+        <categoryLink id="3c38-84d1-499c-b29f" name="Fleet Commander" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="false">
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0139-290c-071b-822f" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0139-290c-071b-822f" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="4d87-7646-6385-1f6b" name="Grand Cruisers" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false"/>
-        <categoryLink id="2eb8-5f50-dff9-0083" name="Orbital Defences" hidden="false" targetId="90ac-0bee-0c90-be27" primary="false"/>
+        <categoryLink id="4d87-7646-6385-1f6b" name="Grand Cruiser" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false"/>
+        <categoryLink id="2eb8-5f50-dff9-0083" name="Orbital Defence" hidden="false" targetId="90ac-0bee-0c90-be27" primary="false"/>
         <categoryLink id="3981-b463-fcca-6006" name="Ordnance" hidden="false" targetId="e70d-1bf2-7ea2-276a" primary="false"/>
         <categoryLink id="1a5d-de09-874f-cea6" name="Special" hidden="false" targetId="5370656369616c23232344415441232323" primary="false"/>
         <categoryLink id="9ede-dc12-ec80-d62c" name="Reserves" hidden="false" targetId="9624-17a2-bfd7-6420" primary="false"/>
@@ -67,27 +67,27 @@
     </forceEntry>
     <forceEntry id="6018-55bf-7466-ed8a" name="Domination Fleet List" publicationId="1bc8-5968-21c3-0f27" page="30" hidden="false">
       <categoryLinks>
-        <categoryLink id="ab4c-4360-f037-309a" name="Battlecruisers &amp; Heavy Cruisers" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
-        <categoryLink id="6672-b11a-66b5-7aad" name="Battleships" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false">
+        <categoryLink id="ab4c-4360-f037-309a" name="Heavy Cruiser" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
+        <categoryLink id="6672-b11a-66b5-7aad" name="Battleship" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false">
           <modifiers>
-            <modifier type="increment" field="a86b-1303-b7fd-a823" value="1.0">
+            <modifier type="increment" field="a86b-1303-b7fd-a823" value="1">
               <repeats>
-                <repeat field="points" scope="force" value="1000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" repeats="1" roundUp="false"/>
+                <repeat field="points" scope="force" value="1000" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" repeats="1" roundUp="false"/>
               </repeats>
               <conditions>
-                <condition field="points" scope="force" value="1000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="greaterThan"/>
+                <condition field="points" scope="force" value="1000" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a86b-1303-b7fd-a823" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a86b-1303-b7fd-a823" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="511e-63f5-cdcd-82fe" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
-        <categoryLink id="b222-df30-6f8b-bee8" name="Escorts" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
-        <categoryLink id="f632-20f6-244e-14f5" name="Fleet Commanders" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="false"/>
-        <categoryLink id="9eb0-bb37-8903-4ec0" name="Grand Cruisers" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false"/>
-        <categoryLink id="1ad1-478b-1605-b77d" name="Orbital Defences" hidden="false" targetId="90ac-0bee-0c90-be27" primary="false"/>
+        <categoryLink id="511e-63f5-cdcd-82fe" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
+        <categoryLink id="b222-df30-6f8b-bee8" name="Escort" hidden="false" targetId="4573636f72747323232344415441232323" primary="false"/>
+        <categoryLink id="f632-20f6-244e-14f5" name="Fleet Commander" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="false"/>
+        <categoryLink id="9eb0-bb37-8903-4ec0" name="Grand Cruiser" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false"/>
+        <categoryLink id="1ad1-478b-1605-b77d" name="Orbital Defence" hidden="false" targetId="90ac-0bee-0c90-be27" primary="false"/>
         <categoryLink id="1427-59e4-5cac-1fa6" name="Ordnance" hidden="false" targetId="e70d-1bf2-7ea2-276a" primary="false"/>
         <categoryLink id="e128-925e-072e-bd52" name="Special" hidden="false" targetId="5370656369616c23232344415441232323" primary="false"/>
         <categoryLink id="1ea0-4bca-4dfc-7609" name="Reserves" hidden="false" targetId="9624-17a2-bfd7-6420" primary="false"/>
@@ -97,53 +97,53 @@
   <selectionEntries>
     <selectionEntry id="dbe9-4790-7e68-9eb6" name="Battlebarge" page="0" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="a434-09a1-3aaa-c0ed" type="max"/>
+        <constraint field="selections" scope="roster" value="3" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="a434-09a1-3aaa-c0ed" type="max"/>
       </constraints>
       <profiles>
         <profile id="4888-c408-081a-3d4d" name="Battlebarge profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Battleship</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">12</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Battleship</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">12</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">3</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">6+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">3</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">3</characteristic>
           </characteristics>
         </profile>
         <profile id="9a8d-bae7-7b55-bc84" name="Battlebarge Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">12</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="b3ad-77a6-9f0b-3ef8" name="Battlebarge Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">12</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
         <profile id="c095-cc16-3a33-4ecc" name="Battlebarge Prow Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Thnderhakws: 20cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3 Squadrons</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
           </characteristics>
         </profile>
         <profile id="79ac-7d4c-99c0-a36a" name="Battlebarge Prow Torpedos" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
           </characteristics>
         </profile>
         <profile id="8008-54fe-7a70-7933" name="Battlebarge Dorsal bombardment Cannon" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">8</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -151,7 +151,7 @@
         <rule id="2ef6-364c-c6aa-fb67" name="May Not use &quot;Come To A New Heading&quot; special order." hidden="false"/>
       </rules>
       <categoryLinks>
-        <categoryLink id="1678-406c-bdc2-25d2" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true"/>
+        <categoryLink id="1678-406c-bdc2-25d2" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true" name="Battleship"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="95e6-b914-abcd-6a26" name="Honour Guard" page="0" hidden="true" collective="false" import="true" type="upgrade">
@@ -160,22 +160,22 @@
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5401-792b-71dc-1a0d" type="instanceOf"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6018-55bf-7466-ed8a" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5401-792b-71dc-1a0d" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6018-55bf-7466-ed8a" type="instanceOf"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8cb0-7fae-ea8e-c72b" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8cb0-7fae-ea8e-c72b" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="63ba-df0f-1986-0db1" name="Honour Guard" hidden="false" targetId="2ebb-7250-08df-cdd1" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="pts" typeId="points" value="10.0"/>
+            <cost name="pts" typeId="points" value="10"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="32ec-c9f0-a9a7-7531" name="Thunderhawk Annihilator" hidden="true" collective="false" import="true" type="upgrade">
@@ -184,15 +184,15 @@
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5401-792b-71dc-1a0d" type="instanceOf"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5401-792b-71dc-1a0d" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cadc-ceec-31d1-9743" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cadc-ceec-31d1-9743" type="max"/>
           </constraints>
           <rules>
             <rule id="7859-e73b-3776-0610" name="Thunderhawk Annihilator" hidden="false">
@@ -201,7 +201,7 @@ When a Thunderhawk Annihilator comes in contact with an enemy ship’s base, the
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -209,18 +209,18 @@ When a Thunderhawk Annihilator comes in contact with an enemy ship’s base, the
         <entryLink id="4001-bcf6-f5ae-53e2" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="425.0"/>
+        <cost name="pts" typeId="points" value="425"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a8ee-ec79-72ed-2dc1" name="Escort Squadron" page="0" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="00ef-b15c-bc0f-3244" hidden="false" targetId="4573636f72747323232344415441232323" primary="true"/>
+        <categoryLink id="00ef-b15c-bc0f-3244" hidden="false" targetId="4573636f72747323232344415441232323" primary="true" name="Escort"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="df1a-e323-180e-67a7" name="Escorts" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0449-d13b-c6c2-75ad" type="min"/>
-            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="39a6-3c3b-ce36-6766" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0449-d13b-c6c2-75ad" type="min"/>
+            <constraint field="selections" scope="parent" value="6" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="39a6-3c3b-ce36-6766" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="6998-3170-db2e-a587" name="Cobra Rapid Strike Vessel" page="0" hidden="true" collective="false" import="true" type="unit">
@@ -229,49 +229,49 @@ When a Thunderhawk Annihilator comes in contact with an enemy ship’s base, the
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6018-55bf-7466-ed8a" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a2b7-61cb-e479-de43" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6018-55bf-7466-ed8a" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a2b7-61cb-e479-de43" type="instanceOf"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8da6-1b5b-8907-f669" type="max"/>
+                <constraint field="selections" scope="parent" value="6" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8da6-1b5b-8907-f669" type="max"/>
               </constraints>
               <profiles>
                 <profile id="685e-4474-ee8a-be52" name="Cobra Rapid Strike Vessel" publicationId="11f0-17d1-e4d2-1018" page="114" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
                   <characteristics>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Escort/1</characteristic>
-                    <characteristic name="Hits" typeId="4869747323232344415441232323">1</characteristic>
-                    <characteristic name="Speed" typeId="537065656423232344415441232323">30</characteristic>
+                    <characteristic name="Type" typeId="5.479706523232345e+27">Escort/1</characteristic>
+                    <characteristic name="Hits" typeId="4.869747323232344e+27">1</characteristic>
+                    <characteristic name="Speed" typeId="5.370656564232324e+29">30</characteristic>
                     <characteristic name="Turns" typeId="5475726e7323232344415441232323">90</characteristic>
                     <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
                     <characteristic name="Armour" typeId="41726d6f757223232344415441232323">4+</characteristic>
-                    <characteristic name="Turrets" typeId="5475727265747323232344415441232323">1</characteristic>
+                    <characteristic name="Turrets" typeId="5.475727265747323e+33">1</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="f629-0dac-399e-32b1" name="Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/right/front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/right/front</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="5045-d628-ed66-21dd" name="Prow Torpedos" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="a7b1-0ad4-07e8-2c9d" hidden="false" targetId="4573636f72747323232344415441232323" primary="true"/>
+                <categoryLink id="a7b1-0ad4-07e8-2c9d" hidden="false" targetId="4573636f72747323232344415441232323" primary="true" name="Escort"/>
               </categoryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="35.0"/>
+                <cost name="pts" typeId="points" value="35"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b170-856a-5c7c-6663" name="Falchion Rapid Strike Vessel" page="0" hidden="true" collective="false" import="true" type="unit">
@@ -280,48 +280,48 @@ When a Thunderhawk Annihilator comes in contact with an enemy ship’s base, the
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6018-55bf-7466-ed8a" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6018-55bf-7466-ed8a" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="02e8-b44f-ecc2-f9f1" type="max"/>
+                <constraint field="selections" scope="parent" value="6" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="02e8-b44f-ecc2-f9f1" type="max"/>
               </constraints>
               <profiles>
                 <profile id="8700-dcc3-e9f5-19bb" name="Falchion Rapid Strike Vessel" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
                   <characteristics>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Escort</characteristic>
-                    <characteristic name="Hits" typeId="4869747323232344415441232323">1</characteristic>
-                    <characteristic name="Speed" typeId="537065656423232344415441232323">25cm</characteristic>
+                    <characteristic name="Type" typeId="5.479706523232345e+27">Escort</characteristic>
+                    <characteristic name="Hits" typeId="4.869747323232344e+27">1</characteristic>
+                    <characteristic name="Speed" typeId="5.370656564232324e+29">25cm</characteristic>
                     <characteristic name="Turns" typeId="5475726e7323232344415441232323">90°</characteristic>
                     <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
                     <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-                    <characteristic name="Turrets" typeId="5475727265747323232344415441232323">1</characteristic>
+                    <characteristic name="Turrets" typeId="5.475727265747323e+33">1</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="8d8c-6893-272e-71e1" name="Falchion Prow Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="8bb6-0790-d351-a2cb" name="Falchion Prow Torpedoes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="5825-4007-2394-78ee" hidden="false" targetId="4573636f72747323232344415441232323" primary="true"/>
+                <categoryLink id="5825-4007-2394-78ee" hidden="false" targetId="4573636f72747323232344415441232323" primary="true" name="Escort"/>
               </categoryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="40.0"/>
+                <cost name="pts" typeId="points" value="40"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0ba1-27c9-2e82-4b31" name="Firestorm Rapid Strike Vessel" page="0" hidden="true" collective="false" import="true" type="unit">
@@ -330,156 +330,156 @@ When a Thunderhawk Annihilator comes in contact with an enemy ship’s base, the
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6018-55bf-7466-ed8a" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a2b7-61cb-e479-de43" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6018-55bf-7466-ed8a" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a2b7-61cb-e479-de43" type="instanceOf"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="800e-d1eb-f79e-a2fa" type="max"/>
+                <constraint field="selections" scope="parent" value="6" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="800e-d1eb-f79e-a2fa" type="max"/>
               </constraints>
               <profiles>
                 <profile id="4ab0-7bc8-9b3e-f639" name="Firestorm Rapid Strike Vessel" publicationId="11f0-17d1-e4d2-1018" page="113" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
                   <characteristics>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Escort/1</characteristic>
-                    <characteristic name="Hits" typeId="4869747323232344415441232323">1</characteristic>
-                    <characteristic name="Speed" typeId="537065656423232344415441232323">25</characteristic>
+                    <characteristic name="Type" typeId="5.479706523232345e+27">Escort/1</characteristic>
+                    <characteristic name="Hits" typeId="4.869747323232344e+27">1</characteristic>
+                    <characteristic name="Speed" typeId="5.370656564232324e+29">25</characteristic>
                     <characteristic name="Turns" typeId="5475726e7323232344415441232323">90</characteristic>
                     <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
                     <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-                    <characteristic name="Turrets" typeId="5475727265747323232344415441232323">2</characteristic>
+                    <characteristic name="Turrets" typeId="5.475727265747323e+33">2</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="c7ae-a4c1-eeea-19b3" name="Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/right/front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/right/front</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="afb9-79ca-529a-e5ad" name="Prow Lance" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="9fa4-034c-87bf-6d32" hidden="false" targetId="4573636f72747323232344415441232323" primary="true"/>
+                <categoryLink id="9fa4-034c-87bf-6d32" hidden="false" targetId="4573636f72747323232344415441232323" primary="true" name="Escort"/>
               </categoryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="45.0"/>
+                <cost name="pts" typeId="points" value="45"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="97cb-5bc2-00b1-10dd" name="Gladius Frigate" page="0" hidden="false" collective="false" import="true" type="unit">
               <constraints>
-                <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="04c2-929b-c44c-5577" type="max"/>
+                <constraint field="selections" scope="parent" value="6" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="04c2-929b-c44c-5577" type="max"/>
               </constraints>
               <profiles>
                 <profile id="2732-af87-b9ca-7137" name="Gladius Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
                   <characteristics>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Escort</characteristic>
-                    <characteristic name="Hits" typeId="4869747323232344415441232323">1</characteristic>
-                    <characteristic name="Speed" typeId="537065656423232344415441232323">30cm</characteristic>
+                    <characteristic name="Type" typeId="5.479706523232345e+27">Escort</characteristic>
+                    <characteristic name="Hits" typeId="4.869747323232344e+27">1</characteristic>
+                    <characteristic name="Speed" typeId="5.370656564232324e+29">30cm</characteristic>
                     <characteristic name="Turns" typeId="5475726e7323232344415441232323">90°</characteristic>
                     <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
                     <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-                    <characteristic name="Turrets" typeId="5475727265747323232344415441232323">1</characteristic>
+                    <characteristic name="Turrets" typeId="5.475727265747323e+33">1</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="c3a3-f6a1-2ed5-9a06" name="Gladius Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="bdd8-ffdb-0521-2f62" hidden="false" targetId="4573636f72747323232344415441232323" primary="true"/>
+                <categoryLink id="bdd8-ffdb-0521-2f62" hidden="false" targetId="4573636f72747323232344415441232323" primary="true" name="Escort"/>
               </categoryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="45.0"/>
+                <cost name="pts" typeId="points" value="45"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c5c3-f6a3-5082-339c" name="Hunter Destroyer" page="0" hidden="false" collective="false" import="true" type="unit">
               <constraints>
-                <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6a66-11b0-93eb-bb32" type="max"/>
+                <constraint field="selections" scope="parent" value="6" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6a66-11b0-93eb-bb32" type="max"/>
               </constraints>
               <profiles>
                 <profile id="87c2-efed-fc02-67da" name="Hunter Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
                   <characteristics>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Escort</characteristic>
-                    <characteristic name="Hits" typeId="4869747323232344415441232323">1</characteristic>
-                    <characteristic name="Speed" typeId="537065656423232344415441232323">35cm</characteristic>
+                    <characteristic name="Type" typeId="5.479706523232345e+27">Escort</characteristic>
+                    <characteristic name="Hits" typeId="4.869747323232344e+27">1</characteristic>
+                    <characteristic name="Speed" typeId="5.370656564232324e+29">35cm</characteristic>
                     <characteristic name="Turns" typeId="5475726e7323232344415441232323">90°</characteristic>
                     <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
                     <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-                    <characteristic name="Turrets" typeId="5475727265747323232344415441232323">1</characteristic>
+                    <characteristic name="Turrets" typeId="5.475727265747323e+33">1</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="b91b-e5f4-8b2e-89b8" name="Hunter Torpedoes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="da1a-99c3-2a62-c1a9" name="Hunter Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="b0d2-56a8-dd41-22aa" hidden="false" targetId="4573636f72747323232344415441232323" primary="true"/>
+                <categoryLink id="b0d2-56a8-dd41-22aa" hidden="false" targetId="4573636f72747323232344415441232323" primary="true" name="Escort"/>
               </categoryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="40.0"/>
+                <cost name="pts" typeId="points" value="40"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1881-41d7-23be-64d3" name="Nova Frigate" page="0" hidden="false" collective="false" import="true" type="unit">
               <constraints>
-                <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a669-8f1a-673e-2304" type="max"/>
+                <constraint field="selections" scope="parent" value="6" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a669-8f1a-673e-2304" type="max"/>
               </constraints>
               <profiles>
                 <profile id="d7fe-e7ca-85c8-b508" name="Nova Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
                   <characteristics>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Escort</characteristic>
-                    <characteristic name="Hits" typeId="4869747323232344415441232323">1</characteristic>
-                    <characteristic name="Speed" typeId="537065656423232344415441232323">35cm</characteristic>
+                    <characteristic name="Type" typeId="5.479706523232345e+27">Escort</characteristic>
+                    <characteristic name="Hits" typeId="4.869747323232344e+27">1</characteristic>
+                    <characteristic name="Speed" typeId="5.370656564232324e+29">35cm</characteristic>
                     <characteristic name="Turns" typeId="5475726e7323232344415441232323">90°</characteristic>
                     <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
                     <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-                    <characteristic name="Turrets" typeId="5475727265747323232344415441232323">1</characteristic>
+                    <characteristic name="Turrets" typeId="5.475727265747323e+33">1</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="75bb-73b1-7491-9842" name="Nova Lance" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="d7e1-139a-f3ec-4565" name="Nova Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="9564-cb7d-bd06-17c2" hidden="false" targetId="4573636f72747323232344415441232323" primary="true"/>
+                <categoryLink id="9564-cb7d-bd06-17c2" hidden="false" targetId="4573636f72747323232344415441232323" primary="true" name="Escort"/>
               </categoryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="50.0"/>
+                <cost name="pts" typeId="points" value="50"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9dc6-853a-2332-9990" name="Sword Rapid Strike Vessel" page="0" hidden="true" collective="false" import="true" type="unit">
@@ -488,42 +488,42 @@ When a Thunderhawk Annihilator comes in contact with an enemy ship’s base, the
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6018-55bf-7466-ed8a" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a2b7-61cb-e479-de43" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6018-55bf-7466-ed8a" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a2b7-61cb-e479-de43" type="instanceOf"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4c3f-9d95-0fde-bb13" type="max"/>
+                <constraint field="selections" scope="parent" value="6" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4c3f-9d95-0fde-bb13" type="max"/>
               </constraints>
               <profiles>
                 <profile id="9b80-f4a9-7ef2-c0bc" name="Sword Rapid Strike Vessel" publicationId="11f0-17d1-e4d2-1018" page="113" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
                   <characteristics>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Escort/1</characteristic>
-                    <characteristic name="Hits" typeId="4869747323232344415441232323">1</characteristic>
-                    <characteristic name="Speed" typeId="537065656423232344415441232323">25</characteristic>
+                    <characteristic name="Type" typeId="5.479706523232345e+27">Escort/1</characteristic>
+                    <characteristic name="Hits" typeId="4.869747323232344e+27">1</characteristic>
+                    <characteristic name="Speed" typeId="5.370656564232324e+29">25</characteristic>
                     <characteristic name="Turns" typeId="5475726e7323232344415441232323">90</characteristic>
                     <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
                     <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-                    <characteristic name="Turrets" typeId="5475727265747323232344415441232323">2</characteristic>
+                    <characteristic name="Turrets" typeId="5.475727265747323e+33">2</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="3160-419b-5337-7501" name="Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/right/front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/right/front</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="496c-c50f-698f-f0fb" hidden="false" targetId="4573636f72747323232344415441232323" primary="true"/>
+                <categoryLink id="496c-c50f-698f-f0fb" hidden="false" targetId="4573636f72747323232344415441232323" primary="true" name="Escort"/>
               </categoryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="40.0"/>
+                <cost name="pts" typeId="points" value="40"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -533,12 +533,12 @@ When a Thunderhawk Annihilator comes in contact with an enemy ship’s base, the
         <entryLink id="8a0b-3088-6101-c4af" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="fd77-ef21-fa3c-1591" name="Master of the Fleet" page="0" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="71d5-169e-8550-2dc8" type="max"/>
+        <constraint field="selections" scope="roster" value="1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="71d5-169e-8550-2dc8" type="max"/>
       </constraints>
       <profiles>
         <profile id="3ebc-911f-d011-b93b" name="Master of the Fleet" publicationId="1bc8-5968-21c3-0f27" page="30" hidden="false" typeId="436f6d6d616e64657223232344415441232323" typeName="Commander">
@@ -546,17 +546,17 @@ When a Thunderhawk Annihilator comes in contact with an enemy ship’s base, the
           <modifiers>
             <modifier type="increment" field="52652d726f6c6c7323232344415441232323" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="484d-f978-aa9b-c01d" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="484d-f978-aa9b-c01d" type="equalTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="52652d726f6c6c7323232344415441232323" value="2">
               <conditions>
-                <condition field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="484d-f978-aa9b-c01d" type="equalTo"/>
+                <condition field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="484d-f978-aa9b-c01d" type="equalTo"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="52652d726f6c6c7323232344415441232323" value="3">
               <conditions>
-                <condition field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="484d-f978-aa9b-c01d" type="equalTo"/>
+                <condition field="selections" scope="parent" value="3" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="484d-f978-aa9b-c01d" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -568,38 +568,38 @@ When a Thunderhawk Annihilator comes in contact with an enemy ship’s base, the
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="7e94-af68-f0ab-f4fa" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="true"/>
+        <categoryLink id="7e94-af68-f0ab-f4fa" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="true" name="Fleet Commander"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="484d-f978-aa9b-c01d" name="Extra Re-Rolls (Max 3)" page="0" hidden="false" collective="false" import="true" type="unit">
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fdbf-22e8-e366-a832" type="max"/>
+            <constraint field="selections" scope="parent" value="3" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fdbf-22e8-e366-a832" type="max"/>
           </constraints>
           <costs>
-            <cost name="pts" typeId="points" value="25.0"/>
+            <cost name="pts" typeId="points" value="25"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="3715-0a46-b5f6-c9fb" name="Terminator Boarding Party" hidden="false" collective="false" import="true" type="upgrade">
           <comment>this is in the BBB and the 2010 compendium</comment>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4827-4071-f241-af2b" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4827-4071-f241-af2b" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="e558-aebd-7c19-b6d0" name="Terminator Boarding Party" hidden="false" targetId="067e-eced-a1c9-78a6" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="pts" typeId="points" value="50.0"/>
+            <cost name="pts" typeId="points" value="50"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
-        <cost name="pts" typeId="points" value="50.0"/>
+        <cost name="pts" typeId="points" value="50"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="cf6d-2889-24aa-122e" name="Strike Cruiser" publicationId="5766-7751-d146-0800" page="59" hidden="false" collective="false" import="true" type="unit">
       <comment>2010 compendium 59 all strike cruser profiles are replaced with this profile. Old profile in aramada 23</comment>
       <constraints>
-        <constraint field="selections" scope="roster" value="10.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="d1e7-5937-666d-2d65" type="max"/>
+        <constraint field="selections" scope="roster" value="10" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="d1e7-5937-666d-2d65" type="max"/>
       </constraints>
       <profiles>
         <profile id="a884-02a3-15f7-90b4" name="Strike Cruiser Profile" publicationId="1bc8-5968-21c3-0f27" page="23" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
@@ -607,37 +607,37 @@ When a Thunderhawk Annihilator comes in contact with an enemy ship’s base, the
           <modifiers>
             <modifier type="increment" field="536869656c647323232344415441232323" value="1">
               <conditions>
-                <condition field="selections" scope="cf6d-2889-24aa-122e" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5fe3-e711-da99-b71c" type="equalTo"/>
+                <condition field="selections" scope="cf6d-2889-24aa-122e" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5fe3-e711-da99-b71c" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">6</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">25cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">6</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">25cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">90°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">1</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">6+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">2</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">2</characteristic>
           </characteristics>
         </profile>
         <profile id="c3d0-7a78-6443-69c4" name="Strike Cruiser Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
           </characteristics>
         </profile>
         <profile id="c839-b97f-5f8b-821e" name="Strike Cruiser Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
           <characteristics>
             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="9694-33bf-67a8-7bc9" name="New CategoryLink" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
+        <categoryLink id="9694-33bf-67a8-7bc9" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="5fe3-e711-da99-b71c" name="Additional Shield" publicationId="5766-7751-d146-0800" page="59" hidden="true" collective="false" import="true" type="upgrade">
@@ -646,20 +646,20 @@ When a Thunderhawk Annihilator comes in contact with an enemy ship’s base, the
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5401-792b-71dc-1a0d" type="instanceOf"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a2b7-61cb-e479-de43" type="instanceOf"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6018-55bf-7466-ed8a" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5401-792b-71dc-1a0d" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a2b7-61cb-e479-de43" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6018-55bf-7466-ed8a" type="instanceOf"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5953-1b30-dac4-c654" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5953-1b30-dac4-c654" type="max"/>
           </constraints>
           <costs>
-            <cost name="pts" typeId="points" value="15.0"/>
+            <cost name="pts" typeId="points" value="15"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="eb7f-eea1-4598-80b1" name="Honour Guard" page="0" hidden="true" collective="false" import="true" type="upgrade">
@@ -668,30 +668,30 @@ When a Thunderhawk Annihilator comes in contact with an enemy ship’s base, the
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6018-55bf-7466-ed8a" type="instanceOf"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5401-792b-71dc-1a0d" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6018-55bf-7466-ed8a" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5401-792b-71dc-1a0d" type="instanceOf"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5287-db4f-eb5b-44b7" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5287-db4f-eb5b-44b7" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="fe4c-6713-f286-dc17" name="Honour Guard" hidden="false" targetId="2ebb-7250-08df-cdd1" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="pts" typeId="points" value="10.0"/>
+            <cost name="pts" typeId="points" value="10"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="5a21-8810-4ca4-51ec" name="Prow Weapon 2" hidden="false" collective="false" import="true" defaultSelectionEntryId="bbdd-ae36-1e04-fcd9">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d957-f207-c41e-c1b0" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f91f-767d-f16b-6052" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d957-f207-c41e-c1b0" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f91f-767d-f16b-6052" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="b711-ed78-6b86-b95c" name="Prow Torpedoes" hidden="false" collective="false" import="true" type="upgrade">
@@ -701,12 +701,12 @@ When a Thunderhawk Annihilator comes in contact with an enemy ship’s base, the
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Torpedoes: 30cm
 Boarding: 30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bbdd-ae36-1e04-fcd9" name="Prow Launch Bays" hidden="false" collective="false" import="true" type="upgrade">
@@ -715,7 +715,7 @@ Boarding: 30cm</characteristic>
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Thunderhawks: 20cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -723,7 +723,7 @@ Boarding: 30cm</characteristic>
                 <infoLink id="32e0-3347-0812-1fb4" name="Thunderhawk Annihilator" hidden="false" targetId="0e4a-30d9-1918-f7ac" type="rule"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4a08-516d-1c07-1086" name="Prow Bombardment Cannon" hidden="false" collective="false" import="true" type="upgrade">
@@ -732,20 +732,20 @@ Boarding: 30cm</characteristic>
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30 cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">5</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="f8fc-7df3-a5c6-b5b4" name="Prow Weapon 1" publicationId="5766-7751-d146-0800" page="59" hidden="false" collective="false" import="true" defaultSelectionEntryId="2db4-55cf-c4d7-3454">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0321-d23d-71c9-d600" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5f1-6e60-88ca-6863" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0321-d23d-71c9-d600" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5f1-6e60-88ca-6863" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="3bb6-70cc-d16f-3015" name="Prow Lance" hidden="true" collective="false" import="true" type="upgrade">
@@ -754,10 +754,10 @@ Boarding: 30cm</characteristic>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6018-55bf-7466-ed8a" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a2b7-61cb-e479-de43" type="instanceOf"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5401-792b-71dc-1a0d" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6018-55bf-7466-ed8a" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a2b7-61cb-e479-de43" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5401-792b-71dc-1a0d" type="instanceOf"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -768,12 +768,12 @@ Boarding: 30cm</characteristic>
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">1</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
+                <cost name="pts" typeId="points" value="20"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2db4-55cf-c4d7-3454" name="Prow Bombardment Cannon" hidden="false" collective="false" import="true" type="upgrade">
@@ -782,12 +782,12 @@ Boarding: 30cm</characteristic>
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -797,31 +797,18 @@ Boarding: 30cm</characteristic>
         <entryLink id="8551-377a-309a-ab98" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="145.0"/>
+        <cost name="pts" typeId="points" value="145"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="375e-25ae-6461-041d" name="Venerable Battlebarge" page="0" hidden="true" collective="false" import="true" type="unit">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6018-55bf-7466-ed8a" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5401-792b-71dc-1a0d" type="instanceOf"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
+    <selectionEntry id="375e-25ae-6461-041d" name="Venerable Battlebarge" page="0" hidden="false" collective="false" import="true" type="unit">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="a60c-620c-7772-7780" type="max"/>
+        <constraint field="selections" scope="roster" value="1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="a60c-620c-7772-7780" type="max"/>
       </constraints>
       <infoLinks>
         <infoLink id="60f4-a7fc-61b6-3fa7" name="Thunderhawk Annihilator" hidden="false" targetId="0e4a-30d9-1918-f7ac" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="79ce-0dec-a488-c075" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true"/>
+        <categoryLink id="79ce-0dec-a488-c075" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true" name="Battleship"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e1d4-3504-795b-b732" name="Honour Guard" page="0" hidden="true" collective="false" import="true" type="upgrade">
@@ -830,347 +817,347 @@ Boarding: 30cm</characteristic>
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5401-792b-71dc-1a0d" type="instanceOf"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5401-792b-71dc-1a0d" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5401-792b-71dc-1a0d" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5401-792b-71dc-1a0d" type="instanceOf"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1295-6901-9911-e4bb" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1295-6901-9911-e4bb" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="cffd-f3f0-08ec-d5c6" name="Honour Guard" hidden="false" targetId="2ebb-7250-08df-cdd1" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="pts" typeId="points" value="10.0"/>
+            <cost name="pts" typeId="points" value="10"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="5fa4-286b-f5e6-0f80" name="Ship Model" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a2b3-547a-35fc-b244" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0c59-0ba9-5ca4-1fce" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a2b3-547a-35fc-b244" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0c59-0ba9-5ca4-1fce" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="22dd-49a9-5376-5d08" name="Emperor Class Battleship" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8f0c-45c7-7c2e-e85b" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8f0c-45c7-7c2e-e85b" type="max"/>
               </constraints>
               <categoryLinks>
-                <categoryLink id="2d24-10e4-0db7-b022" name="Battleships" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false"/>
+                <categoryLink id="2d24-10e4-0db7-b022" name="Battleship" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false"/>
               </categoryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="400.0"/>
+                <cost name="pts" typeId="points" value="400"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="baee-a0d4-b2b9-9480" name="Retribution Class Battleship" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="788d-e186-cf7b-aeff" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="788d-e186-cf7b-aeff" type="max"/>
               </constraints>
               <categoryLinks>
-                <categoryLink id="b14f-6180-1b9d-59b7" name="Battleships" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false"/>
+                <categoryLink id="b14f-6180-1b9d-59b7" name="Battleship" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false"/>
               </categoryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="380.0"/>
+                <cost name="pts" typeId="points" value="380"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6411-7c5c-d982-0329" name="Mars Class Battlecruiser" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6a76-1060-510c-1234" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6a76-1060-510c-1234" type="max"/>
               </constraints>
               <categoryLinks>
-                <categoryLink id="4fad-f6fc-3c0a-1781" name="Heavy Cruisers" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
-                <categoryLink id="680f-eca3-af5a-b625" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
+                <categoryLink id="4fad-f6fc-3c0a-1781" name="Heavy Cruiser" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
+                <categoryLink id="680f-eca3-af5a-b625" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
               </categoryLinks>
               <selectionEntries>
                 <selectionEntry id="7137-9f5e-c0da-7c04" name="Left Column Shift" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="222a-3bfd-a233-02bc" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="222a-3bfd-a233-02bc" type="max"/>
                   </constraints>
                   <costs>
-                    <cost name="pts" typeId="points" value="15.0"/>
+                    <cost name="pts" typeId="points" value="15"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
               <costs>
-                <cost name="pts" typeId="points" value="305.0"/>
+                <cost name="pts" typeId="points" value="305"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="24d5-fd4f-7133-816b" name="Overlord Class Battlecruiser" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d334-6be3-0629-5477" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d334-6be3-0629-5477" type="max"/>
               </constraints>
               <categoryLinks>
-                <categoryLink id="130d-4a79-4e39-6eac" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
-                <categoryLink id="3276-0715-b348-390b" name="Heavy Cruisers" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
+                <categoryLink id="130d-4a79-4e39-6eac" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
+                <categoryLink id="3276-0715-b348-390b" name="Heavy Cruiser" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
               </categoryLinks>
               <selectionEntries>
                 <selectionEntry id="ae02-2297-2b00-0cf8" name="Additional Turret" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="63ea-fb54-49b0-5737" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="63ea-fb54-49b0-5737" type="max"/>
                   </constraints>
                   <costs>
-                    <cost name="pts" typeId="points" value="10.0"/>
+                    <cost name="pts" typeId="points" value="10"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
               <costs>
-                <cost name="pts" typeId="points" value="270.0"/>
+                <cost name="pts" typeId="points" value="270"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4274-f029-a854-046e" name="Emperor Class Battleship" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ee43-59a6-317a-70a9" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ee43-59a6-317a-70a9" type="max"/>
               </constraints>
               <categoryLinks>
-                <categoryLink id="583a-7b51-61a5-6d92" name="Battleships" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false"/>
+                <categoryLink id="583a-7b51-61a5-6d92" name="Battleship" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false"/>
               </categoryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="400.0"/>
+                <cost name="pts" typeId="points" value="400"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8df2-86a0-593b-93d6" name="Apocalypse Class Battleship" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5e44-d59f-7292-00a4" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5e44-d59f-7292-00a4" type="max"/>
               </constraints>
               <categoryLinks>
-                <categoryLink id="b9f2-a94b-cb1d-cd70" name="Battleships" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false"/>
+                <categoryLink id="b9f2-a94b-cb1d-cd70" name="Battleship" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false"/>
               </categoryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="335.0"/>
+                <cost name="pts" typeId="points" value="335"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5b33-a75e-39c4-b944" name="Oberon Class Battleship" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="267d-427d-8979-f171" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="267d-427d-8979-f171" type="max"/>
               </constraints>
               <categoryLinks>
-                <categoryLink id="d74a-829f-7f6d-b209" name="Battleships" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false"/>
+                <categoryLink id="d74a-829f-7f6d-b209" name="Battleship" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false"/>
               </categoryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="335.0"/>
+                <cost name="pts" typeId="points" value="335"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2d4d-44ab-05fc-aaf2" name="Avenger Class Grand Cruiser" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ca60-9bcd-fdbb-35d3" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ca60-9bcd-fdbb-35d3" type="max"/>
               </constraints>
               <categoryLinks>
-                <categoryLink id="9a94-5b14-ac83-367b" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
-                <categoryLink id="f451-231c-dca2-b0b3" name="Grand Cruisers" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false"/>
+                <categoryLink id="9a94-5b14-ac83-367b" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
+                <categoryLink id="f451-231c-dca2-b0b3" name="Grand Cruiser" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false"/>
               </categoryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="265.0"/>
+                <cost name="pts" typeId="points" value="265"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7c1d-73e9-1d54-64a4" name="Exorcist Class Grand Cruiser" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6d8b-ab39-c130-1ef5" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6d8b-ab39-c130-1ef5" type="max"/>
               </constraints>
               <categoryLinks>
-                <categoryLink id="8eb9-3432-34ae-1345" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
-                <categoryLink id="ed0e-0352-85dc-3c0c" name="Grand Cruisers" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false"/>
+                <categoryLink id="8eb9-3432-34ae-1345" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
+                <categoryLink id="ed0e-0352-85dc-3c0c" name="Grand Cruiser" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="695a-7742-5c22-958b" name="Weapons Batteries" hidden="false" collective="false" import="true">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ae3a-19d9-6325-e481" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0f36-1e70-8f42-5c15" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ae3a-19d9-6325-e481" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0f36-1e70-8f42-5c15" type="max"/>
                   </constraints>
                   <selectionEntries>
                     <selectionEntry id="d081-44cc-c11f-f16f" name="Range 45cm S8" page="0" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fcb6-5084-eb13-b95b" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fcb6-5084-eb13-b95b" type="max"/>
                       </constraints>
                       <costs>
-                        <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name="pts" typeId="points" value="0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="a700-a319-b80a-8874" name="Range 30cm S10" page="0" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0f32-2ac9-1c39-6a24" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0f32-2ac9-1c39-6a24" type="max"/>
                       </constraints>
                       <costs>
-                        <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name="pts" typeId="points" value="0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="pts" typeId="points" value="265.0"/>
+                <cost name="pts" typeId="points" value="265"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b534-890f-19ea-1b07" name="Armageddon Class Battlecruiser" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9ba0-c333-1df3-dfaa" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9ba0-c333-1df3-dfaa" type="max"/>
               </constraints>
               <categoryLinks>
-                <categoryLink id="ebff-6dbb-301f-d606" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
-                <categoryLink id="10b5-bf89-0a72-ee3b" name="Heavy Cruisers" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
+                <categoryLink id="ebff-6dbb-301f-d606" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
+                <categoryLink id="10b5-bf89-0a72-ee3b" name="Heavy Cruiser" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
               </categoryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="280.0"/>
+                <cost name="pts" typeId="points" value="280"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="be9b-9bbc-d569-3e5e" name="Hellgate Class Heavy Cruiser" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c595-46e2-fef0-6699" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c595-46e2-fef0-6699" type="max"/>
               </constraints>
               <categoryLinks>
-                <categoryLink id="24c5-21cf-4ae7-0b5b" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
-                <categoryLink id="42b4-3dea-a730-6cbc" name="Heavy Cruisers" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
+                <categoryLink id="24c5-21cf-4ae7-0b5b" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
+                <categoryLink id="42b4-3dea-a730-6cbc" name="Heavy Cruiser" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
               </categoryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="310.0"/>
+                <cost name="pts" typeId="points" value="310"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5542-5528-cde7-81f8" name="Crusade-Era Battlebarge" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f531-dfb6-22e6-26ed" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f531-dfb6-22e6-26ed" type="max"/>
               </constraints>
               <categoryLinks>
-                <categoryLink id="9a87-2b56-9c91-6124" name="Battleships" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false"/>
+                <categoryLink id="9a87-2b56-9c91-6124" name="Battleship" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="017a-9063-5bd3-8b79" name="Broadside Weapons Batteries" hidden="false" collective="false" import="true">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9849-860b-5c5c-8bb5" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4bd0-329f-ce79-c3f3" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9849-860b-5c5c-8bb5" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4bd0-329f-ce79-c3f3" type="max"/>
                   </constraints>
                   <selectionEntries>
                     <selectionEntry id="be94-a5f5-6f6c-cddc" name="Range 60cm S6" page="0" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="497f-ace2-9193-92ef" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="497f-ace2-9193-92ef" type="max"/>
                       </constraints>
                       <costs>
-                        <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name="pts" typeId="points" value="0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="abac-49af-2b70-d171" name="Range 45cm S8" page="0" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4af7-4008-ca3f-9bc4" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4af7-4008-ca3f-9bc4" type="max"/>
                       </constraints>
                       <costs>
-                        <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name="pts" typeId="points" value="0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="2d26-4d1a-4ecf-411d" name="Range 30cm S10" page="0" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f330-a322-582b-b20a" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f330-a322-582b-b20a" type="max"/>
                       </constraints>
                       <costs>
-                        <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name="pts" typeId="points" value="0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="5e0e-f861-d577-d7c0" name="Prow Armament" hidden="false" collective="false" import="true">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4deb-ea61-291c-4247" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8493-423c-27a3-1460" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4deb-ea61-291c-4247" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8493-423c-27a3-1460" type="max"/>
                   </constraints>
                   <selectionEntries>
                     <selectionEntry id="7212-532d-b622-bc1c" name="Torpedoes S8" page="0" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e1a6-e45a-dc00-28da" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e1a6-e45a-dc00-28da" type="max"/>
                       </constraints>
                       <costs>
-                        <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name="pts" typeId="points" value="10"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="dcd3-e806-5310-238e" name="Lances 30cm S4" page="0" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9de0-5eea-655b-d011" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9de0-5eea-655b-d011" type="max"/>
                       </constraints>
                       <costs>
-                        <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name="pts" typeId="points" value="0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="f93b-c556-b224-4f34" name="Dorsal Lances" hidden="false" collective="false" import="true">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="79f4-0254-115b-dc84" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3754-2652-9ee0-815f" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="79f4-0254-115b-dc84" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3754-2652-9ee0-815f" type="max"/>
                   </constraints>
                   <selectionEntries>
                     <selectionEntry id="8c6f-1895-32f8-bc7f" name="Range 45cm S4" page="0" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ad1c-478c-7c7e-fa95" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ad1c-478c-7c7e-fa95" type="max"/>
                       </constraints>
                       <costs>
-                        <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name="pts" typeId="points" value="10"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="21a4-51cb-30b3-e55f" name="Range 60cm S3" page="0" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7ad2-9adf-859c-dbe5" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7ad2-9adf-859c-dbe5" type="max"/>
                       </constraints>
                       <costs>
-                        <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name="pts" typeId="points" value="0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="pts" typeId="points" value="445.0"/>
+                <cost name="pts" typeId="points" value="445"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c5f4-a9e9-73c1-1391" name="Venerable Battlebarge Seditio Opprimere" page="0" hidden="false" collective="false" import="true" type="unit">
               <constraints>
-                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="c8ac-2d82-a45f-20f5" type="max"/>
+                <constraint field="selections" scope="roster" value="1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="c8ac-2d82-a45f-20f5" type="max"/>
               </constraints>
               <profiles>
                 <profile id="1375-becc-23e5-2ff0" name="Seditio Opprimere Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
                   <characteristics>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Battleship</characteristic>
-                    <characteristic name="Hits" typeId="4869747323232344415441232323">12</characteristic>
-                    <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+                    <characteristic name="Type" typeId="5.479706523232345e+27">Battleship</characteristic>
+                    <characteristic name="Hits" typeId="4.869747323232344e+27">12</characteristic>
+                    <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
                     <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
                     <characteristic name="Shields" typeId="536869656c647323232344415441232323">4</characteristic>
                     <characteristic name="Armour" typeId="41726d6f757223232344415441232323">6+</characteristic>
-                    <characteristic name="Turrets" typeId="5475727265747323232344415441232323">4</characteristic>
+                    <characteristic name="Turrets" typeId="5.475727265747323e+33">4</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="9dd8-17a3-e2ad-9142" name="Seditio Opprimere Port Bombardment Cannon" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">8</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="1965-2971-f7f1-39b3" name="Seditio Opprimere Starboard Bombardment Cannon" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">8</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="725c-7701-a718-41fa" name="Seditio Opprimere Dorsal Bombardment Cannon" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">8</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="b68c-7dbb-5294-3865" name="Seditio Opprimere Prow Launch Bay" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Thunderhawks: 20cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2 Squadrons</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="43ec-4c31-7bab-0588" name="Seditio Opprimere Prow Torpedos" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -1178,12 +1165,12 @@ Boarding: 30cm</characteristic>
                 <rule id="3681-0f79-f253-a800" name="May Not use &quot;Come To A New Heading&quot; special order." hidden="false"/>
               </rules>
               <categoryLinks>
-                <categoryLink id="3085-3161-d0c3-a63f" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true"/>
+                <categoryLink id="3085-3161-d0c3-a63f" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true" name="Battleship"/>
               </categoryLinks>
               <selectionEntries>
                 <selectionEntry id="f6b0-dda7-009b-c075" name="Thunderhawk Annihilator" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9dd4-619d-5bf1-5180" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9dd4-619d-5bf1-5180" type="max"/>
                   </constraints>
                   <rules>
                     <rule id="be50-8648-acfb-8c2d" name="Thunderhawk Annihilator" hidden="false">
@@ -1192,103 +1179,103 @@ When a Thunderhawk Annihilator comes in contact with an enemy ship’s base, the
                     </rule>
                   </rules>
                   <costs>
-                    <cost name="pts" typeId="points" value="0.0"/>
+                    <cost name="pts" typeId="points" value="0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
               <costs>
-                <cost name="pts" typeId="points" value="450.0"/>
+                <cost name="pts" typeId="points" value="450"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1403-b508-c96a-fc84" name="Acheron Class Heavy Cruiser" publicationId="11f0-17d1-e4d2-1018" page="190" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
-                <profile id="200f-a7e6-3f56-688e" name="Acheron Profile" page="" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+                <profile id="200f-a7e6-3f56-688e" name="Acheron Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
                   <characteristics>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-                    <characteristic name="Hits" typeId="4869747323232344415441232323">8</characteristic>
-                    <characteristic name="Speed" typeId="537065656423232344415441232323">25cm</characteristic>
+                    <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+                    <characteristic name="Hits" typeId="4.869747323232344e+27">8</characteristic>
+                    <characteristic name="Speed" typeId="5.370656564232324e+29">25cm</characteristic>
                     <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
                     <characteristic name="Shields" typeId="536869656c647323232344415441232323">2</characteristic>
                     <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-                    <characteristic name="Turrets" typeId="5475727265747323232344415441232323">3</characteristic>
+                    <characteristic name="Turrets" typeId="5.475727265747323e+33">3</characteristic>
                   </characteristics>
                 </profile>
-                <profile id="4cc7-8cdf-04b3-9f8e" name="Acheron Port Lance" page="" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
+                <profile id="4cc7-8cdf-04b3-9f8e" name="Acheron Port Lance" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
                   </characteristics>
                 </profile>
-                <profile id="8a70-a8ec-0a31-221f" name="Acheron Starboard Lance Battery" page="" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
+                <profile id="8a70-a8ec-0a31-221f" name="Acheron Starboard Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
                   </characteristics>
                 </profile>
-                <profile id="66e8-de42-0e5d-8536" name="Acheron Dorsal Lance Battery" page="" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
+                <profile id="66e8-de42-0e5d-8536" name="Acheron Dorsal Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
                   </characteristics>
                 </profile>
-                <profile id="ac32-42b3-079d-7302" name="Acheron Prow Weapons Battery" page="" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
+                <profile id="ac32-42b3-079d-7302" name="Acheron Prow Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="7eb3-2526-8318-5e77" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
-                <categoryLink id="d2e5-81c4-f94a-c156" name="Heavy Cruisers" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
+                <categoryLink id="7eb3-2526-8318-5e77" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
+                <categoryLink id="d2e5-81c4-f94a-c156" name="Heavy Cruiser" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
               </categoryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="225.0"/>
+                <cost name="pts" typeId="points" value="225"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4c87-7440-89ad-a81e" name="Desolator Class Battleship" publicationId="11f0-17d1-e4d2-1018" page="118" hidden="false" collective="false" import="true" type="unit">
               <profiles>
-                <profile id="a45c-9211-d8bc-8f69" name="Desolator Profile" page="" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+                <profile id="a45c-9211-d8bc-8f69" name="Desolator Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
                   <characteristics>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Battleship</characteristic>
-                    <characteristic name="Hits" typeId="4869747323232344415441232323">12</characteristic>
-                    <characteristic name="Speed" typeId="537065656423232344415441232323">25cm</characteristic>
+                    <characteristic name="Type" typeId="5.479706523232345e+27">Battleship</characteristic>
+                    <characteristic name="Hits" typeId="4.869747323232344e+27">12</characteristic>
+                    <characteristic name="Speed" typeId="5.370656564232324e+29">25cm</characteristic>
                     <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
                     <characteristic name="Shields" typeId="536869656c647323232344415441232323">4</characteristic>
                     <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-                    <characteristic name="Turrets" typeId="5475727265747323232344415441232323">4</characteristic>
+                    <characteristic name="Turrets" typeId="5.475727265747323e+33">4</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="4b13-0750-d1a2-6a0e" name="Desolator Port Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="5cb3-ba4a-601a-738a" name="Desolator Starboard Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="4a33-2948-b150-f563" name="Desolator Dorsal Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="7afa-b430-c2b4-8e10" name="Desolator Prow Torpedos" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">9</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -1299,58 +1286,58 @@ When a Thunderhawk Annihilator comes in contact with an enemy ship’s base, the
                 </rule>
               </rules>
               <categoryLinks>
-                <categoryLink id="5a44-3d20-ebaf-93b1" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true"/>
+                <categoryLink id="5a44-3d20-ebaf-93b1" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true" name="Battleship"/>
               </categoryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="335.0"/>
+                <cost name="pts" typeId="points" value="335"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="bc37-c187-f798-d09a" name="Despoiler Class Battleship" publicationId="11f0-17d1-e4d2-1018" page="117" hidden="false" collective="false" import="true" type="unit">
+            <selectionEntry id="bc37-c187-f798-d09a" name="Despoiler Class Battleship" publicationId="11f0-17d1-e4d2-1018" page="117" hidden="false" collective="false" import="true" type="unit" flatten="true">
               <profiles>
-                <profile id="32a0-27c4-243b-3eb8" name="Despoiler Profile" page="" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+                <profile id="32a0-27c4-243b-3eb8" name="Despoiler Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
                   <characteristics>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Battleship</characteristic>
-                    <characteristic name="Hits" typeId="4869747323232344415441232323">12</characteristic>
-                    <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+                    <characteristic name="Type" typeId="5.479706523232345e+27">Battleship</characteristic>
+                    <characteristic name="Hits" typeId="4.869747323232344e+27">12</characteristic>
+                    <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
                     <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
                     <characteristic name="Shields" typeId="536869656c647323232344415441232323">4</characteristic>
                     <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-                    <characteristic name="Turrets" typeId="5475727265747323232344415441232323">4</characteristic>
+                    <characteristic name="Turrets" typeId="5.475727265747323e+33">4</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="cb40-981d-b1a9-a40d" name="Despoiler Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="37d7-50c7-7465-ae82" name="Despoiler Port Launch Bay" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
-                    <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Swiftdeaths: 30cm Doomfires: 20cm Dreadclaws: 30cm</characteristic>
-                    <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4 squadrons</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+                    <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Thunderhawks: 20cm</characteristic>
+                    <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2 squadrons</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="3201-26bf-d748-ce44" name="Despoiler Starboard Launch Bay" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
-                    <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Swiftdeaths: 30cm Doomfires: 20cm Dreadclaws: 30cm</characteristic>
-                    <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4 squadrons</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+                    <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Thunderhawks: 20cm</characteristic>
+                    <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2 squadrons</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="fad4-8b68-8470-47f9" name="Despoiler Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
                   </characteristics>
                 </profile>
-                <profile id="c9b8-4a06-765d-21df" name="Despoiler Dorsal Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
+                <profile name="Despoiler Dorsal Lance Battery" typeId="41726d616d656e7423232344415441232323" typeName="Armament" hidden="false" id="a3ad-a990-e905-3391">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -1358,420 +1345,142 @@ When a Thunderhawk Annihilator comes in contact with an enemy ship’s base, the
                 <rule id="45dd-9073-e889-9458" name="May not use the &quot;come to new heading&quot; special order" hidden="false"/>
               </rules>
               <categoryLinks>
-                <categoryLink id="4f84-a3f4-89f5-3d41" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true"/>
+                <categoryLink id="4f84-a3f4-89f5-3d41" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true" name="Battleship"/>
               </categoryLinks>
               <selectionEntryGroups>
-                <selectionEntryGroup id="1528-4765-31c7-9204" name="Type" hidden="false" collective="false" import="true">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d427-21e9-7718-071d" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="879d-d6cc-172b-7897" type="max"/>
-                  </constraints>
+                <selectionEntryGroup name="Prow weapon" id="fdb8-11b2-bcaf-beb0" hidden="false">
                   <selectionEntries>
-                    <selectionEntry id="f238-4e9b-412f-6e93" name="Normal" page="0" hidden="false" collective="false" import="true" type="upgrade">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="dc22-6912-3a18-86ff" type="max"/>
-                      </constraints>
-                      <selectionEntries>
-                        <selectionEntry id="7bd3-cd68-771a-42fe" name="Chaos Lord" page="0" hidden="false" collective="false" import="true" type="upgrade">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a80b-0278-234e-a7bb" type="max"/>
-                          </constraints>
-                          <rules>
-                            <rule id="f31c-550e-3ef8-9ee6" name="Chaos Lord" hidden="false">
-                              <description>Any capital ship, apart from that of the Warmaster, may be captained by a Chaos Lord. If so then add +1 to the Leadership rolled for the ship at the start of the game subject to a maximum of 9.
-
-A Lord may be given a re-roll (which he can use for his own ship or squadron only) at +25 points. A ship commanded by a Lord may be given a single Mark of Chaos from the list above.</description>
-                            </rule>
-                          </rules>
-                          <selectionEntries>
-                            <selectionEntry id="5710-240b-9019-e4e2" name="Re-roll" page="0" hidden="false" collective="false" import="true" type="upgrade">
-                              <constraints>
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c7a0-1972-3a8f-2081" type="max"/>
-                              </constraints>
-                              <costs>
-                                <cost name="pts" typeId="points" value="25.0"/>
-                              </costs>
-                            </selectionEntry>
-                          </selectionEntries>
-                          <selectionEntryGroups>
-                            <selectionEntryGroup id="828c-c10b-25e1-590b" name="Mark" hidden="false" collective="false" import="true">
-                              <constraints>
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2fd7-52c9-1e2e-731c" type="max"/>
-                              </constraints>
-                              <selectionEntries>
-                                <selectionEntry id="f4c8-f78a-1cf4-5ffa" name="Mark of Nurgle" page="0" hidden="false" collective="false" import="true" type="upgrade">
-                                  <rules>
-                                    <rule id="596d-bde0-c7d3-a396" name="Mark of Nurgle" hidden="false">
-                                      <description>The vessel is rank with putrescence and the many plagues of the Lord of Decay. It gains 1 Damage Point and may not be boarded.</description>
-                                    </rule>
-                                  </rules>
-                                  <costs>
-                                    <cost name="pts" typeId="points" value="35.0"/>
-                                  </costs>
-                                </selectionEntry>
-                                <selectionEntry id="a9a1-4a0d-b7e0-8056" name="Mark of Tzeentch" page="0" hidden="false" collective="false" import="true" type="upgrade">
-                                  <rules>
-                                    <rule id="28f6-4c8c-1e3c-202d" name="Mark of Tzeentch" hidden="false">
-                                      <description>The Captain can call upon the power of precognition as well as formidable magics to control his vessel. This ship has an extra re-roll.</description>
-                                    </rule>
-                                  </rules>
-                                  <costs>
-                                    <cost name="pts" typeId="points" value="25.0"/>
-                                  </costs>
-                                </selectionEntry>
-                                <selectionEntry id="b4dc-131f-a772-2d6e" name="Mark of Khorne" page="0" hidden="false" collective="false" import="true" type="upgrade">
-                                  <rules>
-                                    <rule id="f533-7aac-c387-ca94" name="Mark of Khorne" hidden="false">
-                                      <description>Crewed by the homicidal followers of Khorne, the ship is extremely dangerous in boarding actions. It doubles its value in boarding actions.</description>
-                                    </rule>
-                                  </rules>
-                                  <costs>
-                                    <cost name="pts" typeId="points" value="20.0"/>
-                                  </costs>
-                                </selectionEntry>
-                                <selectionEntry id="13dd-d5ab-19cb-5386" name="Mark of Slaanesh" page="0" hidden="false" collective="false" import="true" type="upgrade">
-                                  <rules>
-                                    <rule id="271e-9ae9-66d9-ec6c" name="Mark of Slaanesh" hidden="false">
-                                      <description>The ship is full of the sensation-craving followers of Slaanesh and their siren cries extend into the minds of the crews of nearby enemy ships. Enemy ships within 15cm suffer –2 to their Leadership value.</description>
-                                    </rule>
-                                  </rules>
-                                  <costs>
-                                    <cost name="pts" typeId="points" value="25.0"/>
-                                  </costs>
-                                </selectionEntry>
-                              </selectionEntries>
-                            </selectionEntryGroup>
-                          </selectionEntryGroups>
-                          <costs>
-                            <cost name="pts" typeId="points" value="25.0"/>
-                          </costs>
-                        </selectionEntry>
-                        <selectionEntry id="443c-9bcb-1dc0-7ece" name="Chaos Space Marine crew" page="0" hidden="false" collective="false" import="true" type="upgrade">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d0d5-4570-5d41-e239" type="max"/>
-                          </constraints>
-                          <rules>
-                            <rule id="3ece-37cd-4486-4cea" name="Chaos Space Marine Crew" hidden="false">
-                              <description>Any capital ship can be designated as having a Chaos Space Marine crew at the points cost indicated in the army list. The ship will be subject to the Chaos Space Marine special rules. If the ship contains the Warmaster or a Lord then you can assume that he is also a Chaos Space Marine.
-
-Leadership:
-A vessel with a Chaos Space Marine crew will have +1 Leadership (in addition to any other bonuses due to there being a Chaos Warmaster or Chaos Lord on board). Furthermore the maximum Leadership of the vessel is increased to 10.
-
-Boarding &amp; Hit-&amp;-run:
-The superior fighting skills of the Chaos Space Marines are most apparent in boarding actions. A ship with a Chaos Space Marine crew adds two to its roll when performing boarding actions and enemy conducting hit &amp; run attacks against them subtract one from their hit &amp; run result. Hit and run attacks launched by boarding torpedoes, Dreadclaws, Thunderhawks or teleportation originating from such a ship add 1 to their result.
-
-Planetary Assault:
-Ships with Chaos Space Marine crews in a Planetary Assault mission score two Assault Points for every turn they spend landing troops.</description>
-                            </rule>
-                          </rules>
-                          <selectionEntries>
-                            <selectionEntry id="9f5f-dec6-0911-8e14" name="Terminators" page="0" hidden="false" collective="false" import="true" type="upgrade">
-                              <constraints>
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c37f-18c0-bc9d-b017" type="max"/>
-                              </constraints>
-                              <rules>
-                                <rule id="d258-b284-0eba-379f" name="Terminators" hidden="false">
-                                  <description>For an extra 10 points battleships and grand cruisers with Chaos Space Marine Warmasters, Lords or crews may roll two dice when conducting hit and run teleport attacks and select which one they wish to count. They will add one as normal. This represents them unleashing their Chosen Terminators in a teleport assault.</description>
-                                </rule>
-                              </rules>
-                              <costs>
-                                <cost name="pts" typeId="points" value="10.0"/>
-                              </costs>
-                            </selectionEntry>
-                          </selectionEntries>
-                          <selectionEntryGroups>
-                            <selectionEntryGroup id="5363-c66f-42a6-6edf" name="Mark" hidden="false" collective="false" import="true">
-                              <constraints>
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6361-4a77-b5a6-1995" type="max"/>
-                              </constraints>
-                              <selectionEntries>
-                                <selectionEntry id="a3ac-5d16-5fda-65f3" name="Mark of Nurgle" page="0" hidden="false" collective="false" import="true" type="upgrade">
-                                  <rules>
-                                    <rule id="a41d-b4a4-d326-cbea" name="Mark of Nurgle" hidden="false">
-                                      <description>The vessel is rank with putrescence and the many plagues of the Lord of Decay. It gains 1 Damage Point and may not be boarded.</description>
-                                    </rule>
-                                  </rules>
-                                  <costs>
-                                    <cost name="pts" typeId="points" value="35.0"/>
-                                  </costs>
-                                </selectionEntry>
-                                <selectionEntry id="e8d0-6bbd-b635-702c" name="Mark of Tzeentch" page="0" hidden="false" collective="false" import="true" type="upgrade">
-                                  <rules>
-                                    <rule id="9fd3-d29a-6770-7ad6" name="Mark of Tzeentch" hidden="false">
-                                      <description>The Captain can call upon the power of precognition as well as formidable magics to control his vessel. This ship has an extra re-roll.</description>
-                                    </rule>
-                                  </rules>
-                                  <costs>
-                                    <cost name="pts" typeId="points" value="25.0"/>
-                                  </costs>
-                                </selectionEntry>
-                                <selectionEntry id="a6c2-b271-8cb4-46fd" name="Mark of Khorne" page="0" hidden="false" collective="false" import="true" type="upgrade">
-                                  <rules>
-                                    <rule id="7504-e40e-4e6e-1700" name="Mark of Khorne" hidden="false">
-                                      <description>Crewed by the homicidal followers of Khorne, the ship is extremely dangerous in boarding actions. It doubles its value in boarding actions.</description>
-                                    </rule>
-                                  </rules>
-                                  <costs>
-                                    <cost name="pts" typeId="points" value="20.0"/>
-                                  </costs>
-                                </selectionEntry>
-                                <selectionEntry id="8cf4-94cc-f527-1b14" name="Mark of Slaanesh" page="0" hidden="false" collective="false" import="true" type="upgrade">
-                                  <rules>
-                                    <rule id="930c-850f-a30c-fb38" name="Mark of Slaanesh" hidden="false">
-                                      <description>The ship is full of the sensation-craving followers of Slaanesh and their siren cries extend into the minds of the crews of nearby enemy ships. Enemy ships within 15cm suffer –2 to their Leadership value.</description>
-                                    </rule>
-                                  </rules>
-                                  <costs>
-                                    <cost name="pts" typeId="points" value="25.0"/>
-                                  </costs>
-                                </selectionEntry>
-                              </selectionEntries>
-                            </selectionEntryGroup>
-                          </selectionEntryGroups>
-                          <costs>
-                            <cost name="pts" typeId="points" value="35.0"/>
-                          </costs>
-                        </selectionEntry>
-                      </selectionEntries>
-                      <costs>
-                        <cost name="pts" typeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="90af-eb52-fcfe-e0ac" name="Daemon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4044-e0a7-87e9-9e47" type="max"/>
-                      </constraints>
-                      <rules>
-                        <rule id="28a8-d56f-68f3-5488" name="Daemon" hidden="false">
-                          <description>See Deamonships Special Rules.</description>
-                        </rule>
-                      </rules>
-                      <selectionEntryGroups>
-                        <selectionEntryGroup id="70e2-d71c-48e9-8d59" name="Mark" hidden="false" collective="false" import="true">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="45f6-3859-3e3f-794e" type="max"/>
-                          </constraints>
-                          <selectionEntries>
-                            <selectionEntry id="19ee-592d-2f74-7c4f" name="Mark of Nurgle" page="0" hidden="false" collective="false" import="true" type="upgrade">
-                              <rules>
-                                <rule id="44d7-af17-7e71-7836" name="Mark of Nurgle" hidden="false">
-                                  <description>The vessel is rank with putrescence and the many plagues of the Lord of Decay. It gains 1 Damage Point and may not be boarded.</description>
-                                </rule>
-                              </rules>
-                              <costs>
-                                <cost name="pts" typeId="points" value="35.0"/>
-                              </costs>
-                            </selectionEntry>
-                            <selectionEntry id="28b5-fbad-369a-d7a0" name="Mark of Tzeentch" page="0" hidden="false" collective="false" import="true" type="upgrade">
-                              <rules>
-                                <rule id="94ee-7e77-2dfd-7631" name="Mark of Tzeentch" hidden="false">
-                                  <description>The Captain can call upon the power of precognition as well as formidable magics to control his vessel. This ship has an extra re-roll.</description>
-                                </rule>
-                              </rules>
-                              <costs>
-                                <cost name="pts" typeId="points" value="25.0"/>
-                              </costs>
-                            </selectionEntry>
-                            <selectionEntry id="8b2b-9654-c4d5-f607" name="Mark of Khorne" page="0" hidden="false" collective="false" import="true" type="upgrade">
-                              <rules>
-                                <rule id="e764-70ab-9b97-9092" name="Mark of Khorne" hidden="false">
-                                  <description>Crewed by the homicidal followers of Khorne, the ship is extremely dangerous in boarding actions. It doubles its value in boarding actions.</description>
-                                </rule>
-                              </rules>
-                              <costs>
-                                <cost name="pts" typeId="points" value="20.0"/>
-                              </costs>
-                            </selectionEntry>
-                            <selectionEntry id="02a9-92c1-3490-368e" name="Mark of Slaanesh" page="0" hidden="false" collective="false" import="true" type="upgrade">
-                              <rules>
-                                <rule id="8694-5acc-618e-6a4d" name="Mark of Slaanesh" hidden="false">
-                                  <description>The ship is full of the sensation-craving followers of Slaanesh and their siren cries extend into the minds of the crews of nearby enemy ships. Enemy ships within 15cm suffer –2 to their Leadership value.</description>
-                                </rule>
-                              </rules>
-                              <costs>
-                                <cost name="pts" typeId="points" value="25.0"/>
-                              </costs>
-                            </selectionEntry>
-                          </selectionEntries>
-                        </selectionEntryGroup>
-                      </selectionEntryGroups>
-                      <costs>
-                        <cost name="pts" typeId="points" value="50.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="2ede-98f1-a8db-80de" name="Ordnance" hidden="false" collective="false" import="true">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b92b-469f-5c93-fe5d" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="491f-42f1-ed13-2fcd" type="max"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="cacd-0ee5-5877-5deb" name="Thunderhawk Gunship" hidden="false" collective="false" import="true" type="upgrade">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fd6-b3b2-097f-a373" type="max"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7356-0e23-e99d-0f09" type="min"/>
-                      </constraints>
-                      <rules>
-                        <rule id="8f1d-6b12-5eb5-604e" name="Thunderhawk Gunship" hidden="false">
-                          <description>A ship with a Chaos Space Marine crew may be equipped with Thunderhawk Gunships but if so it may only carry Thunderhawks and may not launch Swiftdeaths, Doomfires and Dreadclaws. Furthermore the launch capacity of the ship’s bays’ is halved (round down). This is because the launch bays have to be substantially rebuilt to deal with the larger Thunderhawks.
-
-Thunderhawk gunships combine the abilities of assault boats and fighters, and move like any other attack craft, with a speed of 20cm. A Thunderhawk counter that is intercepted by enemy fighters or moves onto an enemy ordnance marker removes the enemy as fighters would. However as they are extremely resilient, roll a dice when this happens. On a score of 4+, do not remove the Thunderhawk marker (However, Thunderhawks can only remove one enemy marker in any given ordnance phase and stop moving as soon as they intercept an enemy. Also, if a Thunderhawk marker uses its save to remain in play and comes into contact with another ordnance marker in the same ordnance phase, it is removed normally.). Note that against Eldar fighters, which also have this ability, it is possible that you end up with neither marker being removed! If this happens, either marker is free to move away in their next turn, or they can stay in place and attempt to remove their enemy again.
-
-When a Thunderhawk marker moves into contact with an enemy ship’s base, they are treated exactly like assault boats (with the +1 bonus to their hit and run attack for being Space Marines). Using its 4+ save does not prevent it from attacking a ship if in base contact with one when stopped. Once a Thunderhawk marker has made its hit and run attack, it is removed from play.</description>
-                        </rule>
-                      </rules>
-                      <costs>
-                        <cost name="pts" typeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="052c-3658-465f-9859" name="The Damnation&apos;s Fury" hidden="false" collective="false" import="true">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68b5-a968-105f-a736" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6051-5ed2-3bfd-069c" type="min"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="8648-725e-d385-a588" name="The Damnation&apos;s Fury" hidden="false" collective="false" import="true" type="unit">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4efc-c488-0bd7-ba3a" type="max"/>
-                      </constraints>
+                    <selectionEntry type="upgrade" import="true" name="Despoiler Prow Lance Battery" hidden="false" id="b2b2-3318-ce77-441a">
                       <profiles>
-                        <profile id="ff15-66ce-8198-749c" name="Prow Torpedos" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
-                          <characteristics>
-                            <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
-                            <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">8</characteristic>
-                            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                      <costs>
-                        <cost name="pts" typeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="8993-28b8-88e3-1524" name="Regular Despoiler Class Battleship" hidden="false" collective="false" import="true" type="upgrade">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="046a-1b69-e339-0a28" type="max"/>
-                      </constraints>
-                      <profiles>
-                        <profile id="a0b8-a7c1-74fe-658e" name="Despoiler Prow Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
+                        <profile name="Despoiler Prow Lance Battery" typeId="41726d616d656e7423232344415441232323" typeName="Armament" hidden="false" id="c9b8-4a06-765d-21df">
                           <characteristics>
                             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-                            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                           </characteristics>
                         </profile>
                       </profiles>
-                      <costs>
-                        <cost name="pts" typeId="points" value="0.0"/>
-                      </costs>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Torpedo Tube" hidden="false" id="6834-3262-401e-ef4b">
+                      <profiles>
+                        <profile name="Torpedo Tube" typeId="41726d616d656e7423232344415441232323" typeName="Armament" hidden="false" id="3794-c10c-ee04-1ffc">
+                          <characteristics>
+                            <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Speed: 30cm</characteristic>
+                            <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
+                            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
                     </selectionEntry>
                   </selectionEntries>
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7035-1602-a51b-b55d"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1ec2-0b5b-5bd5-57c9"/>
+                  </constraints>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="pts" typeId="points" value="435.0"/>
+                <cost name="pts" typeId="points" value="435"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2d5d-5fde-3724-625e" name="Executor Class Grand Cruiser" publicationId="1bc8-5968-21c3-0f27" page="39" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="e458-155f-3a01-b4f0" name="Executor Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
                   <characteristics>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Grand Cruiser</characteristic>
-                    <characteristic name="Hits" typeId="4869747323232344415441232323">10</characteristic>
-                    <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+                    <characteristic name="Type" typeId="5.479706523232345e+27">Grand Cruiser</characteristic>
+                    <characteristic name="Hits" typeId="4.869747323232344e+27">10</characteristic>
+                    <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
                     <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
                     <characteristic name="Shields" typeId="536869656c647323232344415441232323">3</characteristic>
                     <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-                    <characteristic name="Turrets" typeId="5475727265747323232344415441232323">3</characteristic>
+                    <characteristic name="Turrets" typeId="5.475727265747323e+33">3</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="e773-8ca0-3768-5278" name="Executor 1st Port Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="ef9d-8c94-a5d0-b299" name="Executor 2nd Port Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="7b91-7f33-d836-08f0" name="Executor 1st Starboard Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="4cd7-ca68-44fe-5022" name="Executor 2st Starboard Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="64f8-ba6f-e28b-5e2d" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
-                <categoryLink id="89bd-7629-6843-56d7" name="Grand Cruisers" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false"/>
+                <categoryLink id="64f8-ba6f-e28b-5e2d" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
+                <categoryLink id="89bd-7629-6843-56d7" name="Grand Cruiser" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false"/>
               </categoryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="245.0"/>
+                <cost name="pts" typeId="points" value="245"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aa3d-5530-8fa4-b578" name="Hades Class Heavy Cruiser" publicationId="11f0-17d1-e4d2-1018" page="121" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="3993-73e3-4d92-f5ad" name="Hades Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
                   <characteristics>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-                    <characteristic name="Hits" typeId="4869747323232344415441232323">8</characteristic>
-                    <characteristic name="Speed" typeId="537065656423232344415441232323">25cm</characteristic>
+                    <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+                    <characteristic name="Hits" typeId="4.869747323232344e+27">8</characteristic>
+                    <characteristic name="Speed" typeId="5.370656564232324e+29">25cm</characteristic>
                     <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
                     <characteristic name="Shields" typeId="536869656c647323232344415441232323">2</characteristic>
                     <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-                    <characteristic name="Turrets" typeId="5475727265747323232344415441232323">2</characteristic>
+                    <characteristic name="Turrets" typeId="5.475727265747323e+33">2</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="1b64-a357-ec44-c334" name="Hades Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">10</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="be2f-30cb-6bb2-102e" name="Hades Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">10</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="26f6-062d-758e-a2f8" name="Hades Dorsal Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="0840-bab1-94dc-a82f" name="Hades Prow Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="a0cf-317f-2607-a305" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
-                <categoryLink id="eb57-f0ea-962c-0375" name="Heavy Cruisers" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
+                <categoryLink id="a0cf-317f-2607-a305" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
+                <categoryLink id="eb57-f0ea-962c-0375" name="Heavy Cruiser" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
               </categoryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="235.0"/>
+                <cost name="pts" typeId="points" value="235"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2b2e-d2b9-9bbb-0537" name="Repulsive Class Grand Cruiser" publicationId="11f0-17d1-e4d2-1018" page="119" hidden="false" collective="false" import="true" type="unit">
@@ -1780,21 +1489,21 @@ When a Thunderhawk marker moves into contact with an enemy ship’s base, they a
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">14</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="f3b3-3b44-bc2c-a59e" name="Repulsive Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">14</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="7d1b-9751-ad40-ad11" name="Repulsive Prow Torpedos" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -1804,56 +1513,56 @@ When a Thunderhawk marker moves into contact with an enemy ship’s base, they a
                 </rule>
               </rules>
               <categoryLinks>
-                <categoryLink id="63f6-a7da-494c-35d4" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
-                <categoryLink id="f0ef-6bf6-ba89-bffa" name="Grand Cruisers" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false"/>
+                <categoryLink id="63f6-a7da-494c-35d4" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
+                <categoryLink id="f0ef-6bf6-ba89-bffa" name="Grand Cruiser" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="c44e-9a44-9b3d-53a3" name="The Bringer of Despair" hidden="false" collective="false" import="true">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90ab-b3ba-050d-ceff" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5d5-de61-3e03-2c04" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90ab-b3ba-050d-ceff" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5d5-de61-3e03-2c04" type="min"/>
                   </constraints>
                   <selectionEntries>
                     <selectionEntry id="ebb1-b1b2-baaf-e9ee" name="Regular Repulsive Class Grand Cruiser" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="950d-c889-adba-bcf2" type="max"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f5d-c7c2-de7f-2b4b" type="min"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="950d-c889-adba-bcf2" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f5d-c7c2-de7f-2b4b" type="min"/>
                       </constraints>
                       <profiles>
                         <profile id="eb7e-8f18-716c-b9a1" name="Repulsive Dorsal Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                           <characteristics>
                             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3</characteristic>
-                            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+                            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
                           </characteristics>
                         </profile>
                       </profiles>
                       <costs>
-                        <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name="pts" typeId="points" value="0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="04fc-0dd7-8ca7-7725" name="Extra Shield" hidden="false" collective="false" import="true">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="612d-6e53-458f-4134" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a37-32df-662a-3130" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="612d-6e53-458f-4134" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a37-32df-662a-3130" type="min"/>
                   </constraints>
                   <selectionEntries>
                     <selectionEntry id="5669-a365-42ab-0053" name="Extra Shield" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f221-8305-4b3d-79f6" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f221-8305-4b3d-79f6" type="max"/>
                       </constraints>
                       <profiles>
                         <profile id="8000-ac8a-5f70-33fe" name="Repulsive Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
                           <characteristics>
-                            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-                            <characteristic name="Hits" typeId="4869747323232344415441232323">10</characteristic>
-                            <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+                            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+                            <characteristic name="Hits" typeId="4.869747323232344e+27">10</characteristic>
+                            <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
                             <characteristic name="Turns" typeId="5475726e7323232344415441232323">14</characteristic>
                             <characteristic name="Shields" typeId="536869656c647323232344415441232323">3</characteristic>
                             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-                            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">3</characteristic>
+                            <characteristic name="Turrets" typeId="5.475727265747323e+33">3</characteristic>
                           </characteristics>
                         </profile>
                       </profiles>
@@ -1863,35 +1572,35 @@ When a Thunderhawk marker moves into contact with an enemy ship’s base, they a
                         </rule>
                       </rules>
                       <costs>
-                        <cost name="pts" typeId="points" value="15.0"/>
+                        <cost name="pts" typeId="points" value="15"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="73d0-4015-f25f-b21d" name="Regular Profile" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65c6-c6ec-9c27-cc5c" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65c6-c6ec-9c27-cc5c" type="max"/>
                       </constraints>
                       <profiles>
                         <profile id="0f63-6225-e161-8da9" name="Repulsive Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
                           <characteristics>
-                            <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-                            <characteristic name="Hits" typeId="4869747323232344415441232323">10</characteristic>
-                            <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+                            <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+                            <characteristic name="Hits" typeId="4.869747323232344e+27">10</characteristic>
+                            <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
                             <characteristic name="Turns" typeId="5475726e7323232344415441232323">14</characteristic>
                             <characteristic name="Shields" typeId="536869656c647323232344415441232323">2</characteristic>
                             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-                            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">3</characteristic>
+                            <characteristic name="Turrets" typeId="5.475727265747323e+33">3</characteristic>
                           </characteristics>
                         </profile>
                       </profiles>
                       <costs>
-                        <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name="pts" typeId="points" value="0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="pts" typeId="points" value="265.0"/>
+                <cost name="pts" typeId="points" value="265"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ce15-c5f5-0b43-9538" name="Retaliator Class Grand Cruiser" publicationId="1bc8-5968-21c3-0f27" page="38" hidden="false" collective="false" import="true" type="upgrade">
@@ -1899,73 +1608,73 @@ When a Thunderhawk marker moves into contact with an enemy ship’s base, they a
               <profiles>
                 <profile id="96ec-3121-1e4c-6d74" name="Retaliator Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
                   <characteristics>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Grand cruiser</characteristic>
-                    <characteristic name="Hits" typeId="4869747323232344415441232323">10</characteristic>
-                    <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+                    <characteristic name="Type" typeId="5.479706523232345e+27">Grand cruiser</characteristic>
+                    <characteristic name="Hits" typeId="4.869747323232344e+27">10</characteristic>
+                    <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
                     <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
                     <characteristic name="Shields" typeId="536869656c647323232344415441232323">3</characteristic>
                     <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-                    <characteristic name="Turrets" typeId="5475727265747323232344415441232323">3</characteristic>
+                    <characteristic name="Turrets" typeId="5.475727265747323e+33">3</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="b193-6913-d777-4dca" name="Retaliator Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="dbe5-4dc7-0db2-fc53" name="Retaliator Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="12f8-6cb5-2b93-f6e0" name="RetaliatorPort Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="16e7-aee1-9e99-c3b2" name="RetaliatorStarboard Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="2a64-0c83-38d0-b15f" name="Retaliator Port Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Swiftdeaths: 30cm Doomfires: 20cm Dreadclaws: 30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2 Squadrons</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="8ec1-ef49-b7d2-3277" name="Retaliator Starboard Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Swiftdeaths: 30cm Doomfires: 20cm Dreadclaws: 30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2 Squadrons</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="4ad4-05ee-3df5-aa64" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
-                <categoryLink id="0621-458d-2d7f-6a88" name="Grand Cruisers" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false"/>
+                <categoryLink id="4ad4-05ee-3df5-aa64" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
+                <categoryLink id="0621-458d-2d7f-6a88" name="Grand Cruiser" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="bb36-e060-0dd3-7154" name="Ordnance" hidden="false" collective="false" import="true">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6325-aa85-57b8-3fa9" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b724-4634-9228-470d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6325-aa85-57b8-3fa9" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b724-4634-9228-470d" type="max"/>
                   </constraints>
                   <selectionEntries>
                     <selectionEntry id="cf60-a395-9d40-820b" name="Thunderhawk Gunship" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3625-ae84-a542-6a14" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bd2-524c-592d-e013" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3625-ae84-a542-6a14" type="min"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bd2-524c-592d-e013" type="max"/>
                       </constraints>
                       <rules>
                         <rule id="504e-1f25-bd2f-254d" name="Thunderhawk Gunship" hidden="false">
@@ -1977,73 +1686,73 @@ When a Thunderhawk marker moves into contact with an enemy ship’s base, they a
                         </rule>
                       </rules>
                       <costs>
-                        <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name="pts" typeId="points" value="0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="pts" typeId="points" value="295.0"/>
+                <cost name="pts" typeId="points" value="295"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ae70-a2ff-df63-20c0" name="Styx Class Heavy Cruiser" publicationId="5766-7751-d146-0800" page="23" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="0d88-0624-7f1f-0215" name="Styx Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
                   <characteristics>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Cruiser</characteristic>
-                    <characteristic name="Hits" typeId="4869747323232344415441232323">8</characteristic>
-                    <characteristic name="Speed" typeId="537065656423232344415441232323">25cm</characteristic>
+                    <characteristic name="Type" typeId="5.479706523232345e+27">Cruiser</characteristic>
+                    <characteristic name="Hits" typeId="4.869747323232344e+27">8</characteristic>
+                    <characteristic name="Speed" typeId="5.370656564232324e+29">25cm</characteristic>
                     <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
                     <characteristic name="Shields" typeId="536869656c647323232344415441232323">2</characteristic>
                     <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-                    <characteristic name="Turrets" typeId="5475727265747323232344415441232323">3</characteristic>
+                    <characteristic name="Turrets" typeId="5.475727265747323e+33">3</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="6ab1-6527-dc85-3e29" name="Styx Dorsal Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="cfeb-cf38-66d5-e893" name="Styx Prow Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="beb8-94d0-bcfe-365c" name="Styx Starboard Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Swiftdeaths: 30cm Doomfires: 20cm Dreadclaws: 30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3 Squadrons</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="813c-5cd4-8541-d18c" name="Styx Port Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Swiftdeaths: 30cm Doomfires: 20cm Dreadclaws: 30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3 Squadrons</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="9493-fde5-9e41-9da5" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
-                <categoryLink id="3a13-2709-b210-da14" name="Heavy Cruisers" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
+                <categoryLink id="9493-fde5-9e41-9da5" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
+                <categoryLink id="3a13-2709-b210-da14" name="Heavy Cruiser" hidden="false" targetId="cf79-82ee-ebe9-7ea3" primary="false"/>
               </categoryLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="8a00-4806-3502-cf46" name="Ordnance" hidden="false" collective="false" import="true">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3885-c952-c878-a885" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f811-2f64-ce98-2496" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3885-c952-c878-a885" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f811-2f64-ce98-2496" type="max"/>
                   </constraints>
                   <selectionEntries>
                     <selectionEntry id="599b-b430-e6c8-57bd" name="Thunderhawk Gunship" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b5c-0ce3-e032-ed32" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="947b-a518-e326-d77a" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b5c-0ce3-e032-ed32" type="min"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="947b-a518-e326-d77a" type="max"/>
                       </constraints>
                       <rules>
                         <rule id="28d9-585b-a6cb-e56d" name="Thunderhawk Gunship" hidden="false">
@@ -2055,55 +1764,55 @@ When a Thunderhawk marker moves into contact with an enemy ship’s base, they a
                         </rule>
                       </rules>
                       <costs>
-                        <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name="pts" typeId="points" value="0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="pts" typeId="points" value="295.0"/>
+                <cost name="pts" typeId="points" value="295"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e9ae-f678-94d9-7681" name="Vengeance Class Grand Cruiser" publicationId="1bc8-5968-21c3-0f27" page="14" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="3af2-cc38-759f-76fc" name="Vengeance Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
                   <characteristics>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Grand Cruiser</characteristic>
-                    <characteristic name="Hits" typeId="4869747323232344415441232323">10</characteristic>
-                    <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+                    <characteristic name="Type" typeId="5.479706523232345e+27">Grand Cruiser</characteristic>
+                    <characteristic name="Hits" typeId="4.869747323232344e+27">10</characteristic>
+                    <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
                     <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
                     <characteristic name="Shields" typeId="536869656c647323232344415441232323">3</characteristic>
                     <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-                    <characteristic name="Turrets" typeId="5475727265747323232344415441232323">3</characteristic>
+                    <characteristic name="Turrets" typeId="5.475727265747323e+33">3</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="0ef2-fc99-de9c-f68e" name="Vengeance Port Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="8b76-65cc-d9cb-b40e" name="Vengeance Starboard Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="a1dc-68a9-5e3a-e372" name="Vengeance Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">10</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="9dad-8f75-5f2e-7501" name="Vengeance Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">10</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -2113,45 +1822,45 @@ When a Thunderhawk marker moves into contact with an enemy ship’s base, they a
                 </rule>
               </rules>
               <categoryLinks>
-                <categoryLink id="1ba7-4829-7d85-435a" name="Cruisers" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
-                <categoryLink id="4f78-7b0b-0bf7-8f28" name="Grand Cruisers" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false"/>
+                <categoryLink id="1ba7-4829-7d85-435a" name="Cruiser" hidden="false" targetId="1042-e458-4e02-a537" primary="false"/>
+                <categoryLink id="4f78-7b0b-0bf7-8f28" name="Grand Cruiser" hidden="false" targetId="46e2-c9eb-27e7-172a" primary="false"/>
               </categoryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="265.0"/>
+                <cost name="pts" typeId="points" value="265"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="abf3-e676-af42-123f" name="Loyalist Venerable Battlebarge" publicationId="5766-7751-d146-0800" page="111" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="8936-9dd3-f133-cb4e" name="Vengeful Spirit Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
                   <characteristics>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Battleship</characteristic>
-                    <characteristic name="Hits" typeId="4869747323232344415441232323">12</characteristic>
-                    <characteristic name="Speed" typeId="537065656423232344415441232323">20cm</characteristic>
+                    <characteristic name="Type" typeId="5.479706523232345e+27">Battleship</characteristic>
+                    <characteristic name="Hits" typeId="4.869747323232344e+27">12</characteristic>
+                    <characteristic name="Speed" typeId="5.370656564232324e+29">20cm</characteristic>
                     <characteristic name="Turns" typeId="5475726e7323232344415441232323">45°</characteristic>
                     <characteristic name="Shields" typeId="536869656c647323232344415441232323">4</characteristic>
                     <characteristic name="Armour" typeId="41726d6f757223232344415441232323">5+</characteristic>
-                    <characteristic name="Turrets" typeId="5475727265747323232344415441232323">4</characteristic>
+                    <characteristic name="Turrets" typeId="5.475727265747323e+33">4</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="9365-2e39-09ce-5eca" name="Vengeful Spirit Port Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Swiftdeaths: 30cm Doomfires: 20cm Dreadclaws: 30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="1264-fd86-e702-5a99" name="Vengeful Spirit Starboard Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Swiftdeaths: 30cm Doomfires: 20cm Dreadclaws: 30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
                   </characteristics>
                 </profile>
                 <profile id="982b-b14d-18a3-30a0" name="Vengeful Spirit Prow Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                   <characteristics>
                     <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Swiftdeaths: 30cm Doomfires: 20cm Dreadclaws: 30cm</characteristic>
                     <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">2</characteristic>
-                    <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">-</characteristic>
+                    <characteristic name="Fire Arc" typeId="4.669726520417263e+35">-</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -2165,99 +1874,99 @@ When a Thunderhawk marker moves into contact with an enemy ship’s base, they a
                 </rule>
               </rules>
               <categoryLinks>
-                <categoryLink id="3844-d1ef-bba8-526b" name="New CategoryLink" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true"/>
+                <categoryLink id="3844-d1ef-bba8-526b" name="Battleship" hidden="false" targetId="4361706974616c20536869707323232344415441232323" primary="true"/>
               </categoryLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="c98d-477b-9527-cece" name="Chaos Battlebarge Weapons Battery Options" hidden="false" collective="false" import="true">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6df0-989c-8acc-e0de" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3211-6bf7-61e0-3acd" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6df0-989c-8acc-e0de" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3211-6bf7-61e0-3acd" type="min"/>
                   </constraints>
                   <selectionEntries>
                     <selectionEntry id="d328-5b71-860c-f79b" name="Exchange Broadside Weapon Batteries for Range 45cm, Firepower 8" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f473-34aa-df8d-747f" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f473-34aa-df8d-747f" type="max"/>
                       </constraints>
                       <profiles>
                         <profile id="157f-3793-a23f-4e4c" name="Battlebarge Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                           <characteristics>
                             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
                             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">8</characteristic>
-                            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+                            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
                           </characteristics>
                         </profile>
                         <profile id="e926-bf85-4ec0-3c9c" name="Battlebarge Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                           <characteristics>
                             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
                             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">8</characteristic>
-                            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+                            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
                           </characteristics>
                         </profile>
                       </profiles>
                       <costs>
-                        <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name="pts" typeId="points" value="0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="b5f5-b0a5-4a5f-756a" name="Exchange Broadside Weapon Batteries for Range-30cm, Firepower-10." hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17cb-a77f-ecfa-ca4a" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17cb-a77f-ecfa-ca4a" type="max"/>
                       </constraints>
                       <profiles>
                         <profile id="b936-910c-8676-34de" name="Battlebarge Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                           <characteristics>
                             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">10</characteristic>
-                            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+                            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
                           </characteristics>
                         </profile>
                         <profile id="55f7-86d5-870e-5d9c" name="Battlebarge Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                           <characteristics>
                             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">10</characteristic>
-                            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+                            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
                           </characteristics>
                         </profile>
                       </profiles>
                       <costs>
-                        <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name="pts" typeId="points" value="0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="6784-2cdf-0202-0b65" name="Vengeful Spirit" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5bf-f438-9c03-4762" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5bf-f438-9c03-4762" type="max"/>
                       </constraints>
                       <profiles>
                         <profile id="ffc9-aceb-523b-199a" name="Vengeful Spirit Port Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                           <characteristics>
                             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
                             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left</characteristic>
+                            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left</characteristic>
                           </characteristics>
                         </profile>
                         <profile id="6dcc-6ec1-ea0b-a8f6" name="Vengeful Spirit Starboard Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                           <characteristics>
                             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
                             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">6</characteristic>
-                            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Right</characteristic>
+                            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Right</characteristic>
                           </characteristics>
                         </profile>
                       </profiles>
                       <costs>
-                        <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name="pts" typeId="points" value="0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="0360-d125-c5b7-ad8a" name="Ordnance" hidden="false" collective="false" import="true">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d934-da17-7709-94ff" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9816-953f-19bd-6d6f" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d934-da17-7709-94ff" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9816-953f-19bd-6d6f" type="max"/>
                   </constraints>
                   <selectionEntries>
                     <selectionEntry id="3382-9040-486f-5d4b" name="Thunderhawk Gunship" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b2a-ade9-0ff4-0176" type="max"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55d5-03a0-f2a9-1a00" type="min"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b2a-ade9-0ff4-0176" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55d5-03a0-f2a9-1a00" type="min"/>
                       </constraints>
                       <rules>
                         <rule id="812e-d6bd-49c6-cc63" name="Thunderhawk Gunship" hidden="false">
@@ -2269,27 +1978,27 @@ When a Thunderhawk marker moves into contact with an enemy ship’s base, they a
                         </rule>
                       </rules>
                       <costs>
-                        <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name="pts" typeId="points" value="0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="3e55-a16c-f3c8-56e5" name="Chaos Battlebarge Prow Weapons Options" hidden="false" collective="false" import="true">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed90-4826-eab5-a431" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="369b-dd67-b011-af24" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed90-4826-eab5-a431" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="369b-dd67-b011-af24" type="min"/>
                   </constraints>
                   <selectionEntries>
                     <selectionEntry id="d90f-eb21-69b2-57d4" name="Torpedo Tubes" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6ea-1017-d3af-e3fa" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6ea-1017-d3af-e3fa" type="max"/>
                       </constraints>
                       <profiles>
                         <profile id="ff4f-e1e0-8d88-e33b" name="Chaos Battlebarge Prow Torpedo Tubes" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                           <characteristics>
                             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">8</characteristic>
-                            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Front</characteristic>
+                            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Front</characteristic>
                           </characteristics>
                         </profile>
                       </profiles>
@@ -2299,12 +2008,12 @@ When a Thunderhawk marker moves into contact with an enemy ship’s base, they a
                         </rule>
                       </rules>
                       <costs>
-                        <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name="pts" typeId="points" value="10"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="ad3d-514c-e613-f0d8" name="Vengeful Spirit" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84ed-b8eb-26d1-7e11" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84ed-b8eb-26d1-7e11" type="max"/>
                       </constraints>
                       <profiles>
                         <profile id="eb48-8e22-e49f-3112" name="Vengeful Spirit Prow Lances" hidden="false" typeId="436f6d6d616e64657223232344415441232323" typeName="Commander">
@@ -2316,56 +2025,56 @@ When a Thunderhawk marker moves into contact with an enemy ship’s base, they a
                         </profile>
                       </profiles>
                       <costs>
-                        <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name="pts" typeId="points" value="0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="1fda-5d83-5161-4106" name="Dorsal Weapons Options" hidden="false" collective="false" import="true">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95af-ed50-4468-abc6" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5403-2e45-3f4a-5445" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95af-ed50-4468-abc6" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5403-2e45-3f4a-5445" type="min"/>
                   </constraints>
                   <selectionEntries>
                     <selectionEntry id="8a48-f16c-e2c7-9198" name="Range 45cm, Strength 4 Lances" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06df-372d-efca-86b5" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06df-372d-efca-86b5" type="max"/>
                       </constraints>
                       <profiles>
                         <profile id="5f31-6658-67e2-660e" name="Dorsal Lances" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                           <characteristics>
                             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
                             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">4</characteristic>
-                            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+                            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
                           </characteristics>
                         </profile>
                       </profiles>
                       <costs>
-                        <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name="pts" typeId="points" value="10"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="df85-4b3d-d63b-eddb" name="Vengeful Spirit" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4706-3a2f-45c7-ec70" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4706-3a2f-45c7-ec70" type="max"/>
                       </constraints>
                       <profiles>
                         <profile id="0ee2-f6aa-5aab-e05c" name="Vengeful Spirit Dorsal Lances" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
                           <characteristics>
                             <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
                             <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3</characteristic>
-                            <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Left/Front/Right</characteristic>
+                            <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Left/Front/Right</characteristic>
                           </characteristics>
                         </profile>
                       </profiles>
                       <costs>
-                        <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name="pts" typeId="points" value="0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="pts" typeId="points" value="445.0"/>
+                <cost name="pts" typeId="points" value="445"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2375,7 +2084,7 @@ When a Thunderhawk marker moves into contact with an enemy ship’s base, they a
         <entryLink id="1120-1e0a-eb18-1dcc" name="Leadership" hidden="false" collective="false" import="true" targetId="72b9-2803-264f-57f0" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="bb4b-6197-46d0-f85b" name="Fortress Monastery" page="0" hidden="true" collective="false" import="true" type="unit">
@@ -2384,71 +2093,71 @@ When a Thunderhawk marker moves into contact with an enemy ship’s base, they a
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5401-792b-71dc-1a0d" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5401-792b-71dc-1a0d" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
-        <modifier type="set" field="a65e-16ae-7a5a-71b3" value="0.0">
+        <modifier type="set" field="a65e-16ae-7a5a-71b3" value="0">
           <conditions>
-            <condition field="points" scope="roster" value="2000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="lessThan"/>
+            <condition field="points" scope="roster" value="2000" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="lessThan"/>
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="a65e-16ae-7a5a-71b3" type="max"/>
+        <constraint field="selections" scope="roster" value="1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="a65e-16ae-7a5a-71b3" type="max"/>
       </constraints>
       <profiles>
         <profile id="5c80-4dbf-e945-48d4" name="Fortress Monastery Profile" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Defense</characteristic>
-            <characteristic name="Hits" typeId="4869747323232344415441232323">12 (quadrant)</characteristic>
-            <characteristic name="Speed" typeId="537065656423232344415441232323">0cm</characteristic>
+            <characteristic name="Type" typeId="5.479706523232345e+27">Defense</characteristic>
+            <characteristic name="Hits" typeId="4.869747323232344e+27">12 (quadrant)</characteristic>
+            <characteristic name="Speed" typeId="5.370656564232324e+29">0cm</characteristic>
             <characteristic name="Turns" typeId="5475726e7323232344415441232323">0°</characteristic>
             <characteristic name="Shields" typeId="536869656c647323232344415441232323">4 (quadrant)</characteristic>
             <characteristic name="Armour" typeId="41726d6f757223232344415441232323">6+</characteristic>
-            <characteristic name="Turrets" typeId="5475727265747323232344415441232323">4 (quadrant)</characteristic>
+            <characteristic name="Turrets" typeId="5.475727265747323e+33">4 (quadrant)</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="077b-ee8b-ead0-b3ab" hidden="false" targetId="5370656369616c23232344415441232323" primary="true"/>
+        <categoryLink id="077b-ee8b-ead0-b3ab" hidden="false" targetId="5370656369616c23232344415441232323" primary="true" name="Special"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="eddd-5128-b49d-0f9a" name="Extra Re-Rolls (Max 3)" page="0" hidden="false" collective="false" import="true" type="unit">
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a518-7571-3ead-cda6" type="max"/>
+            <constraint field="selections" scope="parent" value="3" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a518-7571-3ead-cda6" type="max"/>
           </constraints>
           <costs>
-            <cost name="pts" typeId="points" value="25.0"/>
+            <cost name="pts" typeId="points" value="25"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9cd8-695e-cae4-2ec9" name="Quadrant Weapons" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0290-4039-70d4-53ce" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd2a-2269-0db1-a56a" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0290-4039-70d4-53ce" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd2a-2269-0db1-a56a" type="min"/>
           </constraints>
           <profiles>
             <profile id="6a32-6230-644a-1b61" name="Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
               <characteristics>
                 <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
                 <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">18</characteristic>
-                <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Quadrant</characteristic>
+                <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Quadrant</characteristic>
               </characteristics>
             </profile>
             <profile id="0d08-91d0-a8e7-528c" name="Lance Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
               <characteristics>
                 <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">45cm</characteristic>
                 <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3</characteristic>
-                <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Quadrant</characteristic>
+                <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Quadrant</characteristic>
               </characteristics>
             </profile>
             <profile id="0f22-42e5-f3d2-bb91" name="Launch Bays" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
               <characteristics>
                 <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">Thunderhawks: 20cm</characteristic>
                 <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">3 Squadrons*</characteristic>
-                <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">Quadrant</characteristic>
+                <characteristic name="Fire Arc" typeId="4.669726520417263e+35">Quadrant</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -2468,66 +2177,66 @@ When a Thunderhawk Annihilator comes in contact with an enemy ship’s base, the
                 </rule>
               </rules>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e1b9-80c5-4f9b-bede" name="Basilica Weapons" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90a6-b635-43fe-4ef3" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9110-b5e2-3f9f-a777" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90a6-b635-43fe-4ef3" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9110-b5e2-3f9f-a777" type="max"/>
           </constraints>
           <profiles>
             <profile id="65d0-29aa-0aee-13aa" name="Weapons Battery" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
               <characteristics>
                 <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">60cm</characteristic>
                 <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">8</characteristic>
-                <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">All Round</characteristic>
+                <characteristic name="Fire Arc" typeId="4.669726520417263e+35">All Round</characteristic>
               </characteristics>
             </profile>
             <profile id="e6ca-36ef-9f13-8710" name="Torpedo Silos" hidden="false" typeId="41726d616d656e7423232344415441232323" typeName="Armament">
               <characteristics>
                 <characteristic name="Range/Speed" typeId="52616e67652f537065656423232344415441232323">30cm</characteristic>
                 <characteristic name="Firepower/Str" typeId="46697265706f7765722f53747223232344415441232323">9</characteristic>
-                <characteristic name="Fire Arc" typeId="466972652041726323232344415441232323">All Round</characteristic>
+                <characteristic name="Fire Arc" typeId="4.669726520417263e+35">All Round</characteristic>
               </characteristics>
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="5731-f01c-2c05-92c6" name="Honour Guard" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4a7d-0715-058f-55c2" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d16f-2a88-393f-b3c0" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4a7d-0715-058f-55c2" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d16f-2a88-393f-b3c0" type="min"/>
           </constraints>
           <infoLinks>
             <infoLink id="8cea-64c8-5335-1cbf" name="Honour Guard" hidden="false" targetId="2ebb-7250-08df-cdd1" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="88dd-ca3c-c090-3235" name="Terminator Boarding Parties" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e5e-60aa-4a8a-d3f3" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a74-e63b-3826-8ad5" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e5e-60aa-4a8a-d3f3" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a74-e63b-3826-8ad5" type="min"/>
           </constraints>
           <infoLinks>
-            <infoLink id="b66b-f69c-4500-b872" name="Terminator Boarding Parties" hidden="false" targetId="067e-eced-a1c9-78a6" type="rule"/>
+            <infoLink id="b66b-f69c-4500-b872" name="Terminator Boarding Party" hidden="false" targetId="067e-eced-a1c9-78a6" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
-        <cost name="pts" typeId="points" value="1000.0"/>
+        <cost name="pts" typeId="points" value="1000"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2799-f368-bbf8-32eb" name="Space Marines Captain" publicationId="5766-7751-d146-0800" page="61" hidden="true" collective="false" import="true" type="upgrade">
@@ -2536,15 +2245,15 @@ When a Thunderhawk Annihilator comes in contact with an enemy ship’s base, the
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6018-55bf-7466-ed8a" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6018-55bf-7466-ed8a" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <profiles>
-        <profile id="7731-02a0-b63d-e502" name="Space Marines Captain" publicationId="5766-7751-d146-0800" page="61" hidden="false" typeId="5570677261646523232344415441232323" typeName="Upgrade">
+        <profile id="7731-02a0-b63d-e502" name="Space Marines Captain" publicationId="5766-7751-d146-0800" page="61" hidden="false" typeId="5.570677261646523e+33" typeName="Upgrade">
           <characteristics>
             <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Aside from the Space Marine vessels themselves, certain important Imperial Navy vessels within a Dominion Fleet may well have Space Marine commanders assigned to them. Any Imperial Navy battleship, grand cruiser or battlecruiser may have a Space Marine Captain assigned to it. Space Marine Captains roll against the Space Marines leadership table instead of the normal  leadership table. Except for this bonus, Imperial Navy ships led by a  space Marine Captain do not benefit from any of the Space Marines special rules concerning boarding, hit and run attacks, ordnance, etc.
 In addition, a ship led by a Space Marine Captain may carry an Honor Guard for +10 points</characteristic>
@@ -2553,23 +2262,23 @@ In addition, a ship led by a Space Marine Captain may carry an Honor Guard for +
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="9561-db65-9ff2-5fd6" name="New CategoryLink" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="true"/>
+        <categoryLink id="9561-db65-9ff2-5fd6" name="Fleet Commander" hidden="false" targetId="466c65657420436f6d6d616e6465727323232344415441232323" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="6b3d-4115-6dbf-b5ad" name="Honor Guard" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a29-ec1e-c43b-a3b2" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a29-ec1e-c43b-a3b2" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="10ab-11e4-df13-5ea9" name="Honour Guard" hidden="false" targetId="2ebb-7250-08df-cdd1" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="pts" typeId="points" value="10.0"/>
+            <cost name="pts" typeId="points" value="10"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
-        <cost name="pts" typeId="points" value="25.0"/>
+        <cost name="pts" typeId="points" value="25"/>
       </costs>
     </selectionEntry>
   </selectionEntries>
@@ -2578,7 +2287,7 @@ In addition, a ship led by a Space Marine Captain may carry an Honor Guard for +
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5401-792b-71dc-1a0d" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5401-792b-71dc-1a0d" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -2588,7 +2297,7 @@ In addition, a ship led by a Space Marine Captain may carry an Honor Guard for +
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6018-55bf-7466-ed8a" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6018-55bf-7466-ed8a" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -2628,8 +2337,8 @@ When a Thunderhawk marker moves into contact with an enemy ship’s base, they a
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5401-792b-71dc-1a0d" type="notInstanceOf"/>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5401-792b-71dc-1a0d" type="notInstanceOf"/>
+            <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="notInstanceOf"/>
           </conditions>
         </modifier>
       </modifiers>


### PR DESCRIPTION
Working out how the BSData interacts with components.

Made Emperor class battleship available to Battlefleet Bakka as a Reserve option (have to purchase 3 other Battleships first), or by purchasing Fleet Admiral Rath.  Both are valid by the rules.

Had to separate Fleet Admiral Rath from stand Fleet commander section.  Original copy is still there but hidden.

Adjusted Despoiler under Venerable Battle Barge to fit in with the requirements for that position.  Will be updating all Venerable Battle Barge ships in time.