### PR TITLE
Update Space Marine Honour Guard to be only for Dominion Fleets

### DIFF
--- a/Space Marines.cat
+++ b/Space Marines.cat
@@ -160,8 +160,6 @@
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7529-da04-0225-31de" type="instanceOf"/>
-                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5401-792b-71dc-1a0d" type="instanceOf"/>
                     <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6018-55bf-7466-ed8a" type="instanceOf"/>
                   </conditions>
                 </conditionGroup>


### PR DESCRIPTION
Honour Guard are only avaiable to ships with a Space Marine Captain onboard. Space Marine Captain’s are only a Dominion Fleet List concept. Page 100